### PR TITLE
fix:  sha512 length as u128

### DIFF
--- a/plonky2x/src/hash/sha/sha512.rs
+++ b/plonky2x/src/hash/sha/sha512.rs
@@ -433,6 +433,7 @@ pub fn sha512<F: RichField + Extendable<D>, const D: usize>(
     msg_input.extend_from_slice(message);
 
     // TODO: Range check size of msg_bit_len?
+    // Cast to u128 for bitmask
     let msg_bit_len: u128 = message.len().try_into().expect("message too long");
 
     // minimum_padding = 1 + 128 (min 1 bit for the pad, and 128 bit for the msg size)


### PR DESCRIPTION
- previous PR was causing some tests to fail as it casted `msg_bit_len` as a `usize`, when it needs to be a `u128` for the bitmask to parse the length as big endian bits