### PR TITLE
fix: import plonky2x-derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,3 @@ incremental = true
 
 [profile.bench]
 opt-level = 3
-
-
-[patch.crates-io]
-plonky2x = { path = "plonky2x" }
-plonky2x-derive = { path = "plonky2x-derive" }

--- a/plonky2x/Cargo.toml
+++ b/plonky2x/Cargo.toml
@@ -15,7 +15,7 @@ ci = []
 [dependencies]
 plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", default-features = false }
 curta = { git = "https://github.com/succinctlabs/curta.git", branch = "john/nightly" }
-plonky2x-derive = "0.1.0"
+plonky2x-derive = { path = "../plonky2x-derive" }
 
 num = { version = "0.4", default-features = false }
 sha2 = "0.10.7"
@@ -38,7 +38,7 @@ num-bigint = { version = "0.4", features = ["rand"] }
 base64 = "0.13"
 futures = "0.3.28"
 lazy_static = "1.4.0"
-ff = {package="ff" , version="0.13", features = ["derive"]}
+ff = { package = "ff", version = "0.13", features = ["derive"] }
 backtrace = "0.3"
 env_logger = "0.10.0"
 clap = { version = "4.4.0", features = ["derive"] }


### PR DESCRIPTION
Import path for plonky2x-derive was broken when importing from external repo, change to relative path.