### PR TITLE
feat(plonky2x): extend merkle tree

### DIFF
--- a/plonky2x/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/src/frontend/merkle/tendermint.rs
@@ -29,7 +29,6 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
 
             hash_so_far = self.select(path_index, right_hash_pair, left_hash_pair)
         }
-        self.watch(&hash_so_far, "root");
         hash_so_far
     }
 

--- a/plonky2x/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/src/frontend/merkle/tendermint.rs
@@ -1,6 +1,5 @@
 use ethers::types::H256;
 use itertools::Itertools;
-use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 
 use super::tree::MerkleInclusionProofVariable;
 use crate::backend::circuit::PlonkParameters;

--- a/plonky2x/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/src/frontend/merkle/tendermint.rs
@@ -12,21 +12,38 @@ use crate::prelude::{
 /// Merkle Tree implementation for the Tendermint spec (follows Comet BFT Simple Merkle Tree spec: https://docs.cometbft.com/main/spec/core/encoding#merkle-trees).
 /// TODO: Create generic interface for Merkle trees to implement.
 impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
-    pub fn get_root_from_merkle_proof<const PROOF_DEPTH: usize, const LEAF_SIZE_BYTES: usize>(
+    /// Leaf should already be hashed.
+    pub fn get_root_from_merkle_proof_hashed_leaf<const PROOF_DEPTH: usize>(
         &mut self,
-        inclusion_proof: &MerkleInclusionProofVariable<PROOF_DEPTH, LEAF_SIZE_BYTES>,
+        aunts: &ArrayVariable<Bytes32Variable, PROOF_DEPTH>,
+        path_indices: &ArrayVariable<BoolVariable, PROOF_DEPTH>,
+        leaf: Bytes32Variable,
     ) -> Bytes32Variable {
-        let mut hash_so_far = self.leaf_hash(&inclusion_proof.leaf.0);
+        let mut hash_so_far = leaf;
 
         for i in 0..PROOF_DEPTH {
-            let aunt = inclusion_proof.aunts[i];
-            let path_index = inclusion_proof.path_indices[i];
+            let aunt = aunts[i];
+            let path_index = path_indices[i];
             let left_hash_pair = self.inner_hash(&hash_so_far, &aunt);
             let right_hash_pair = self.inner_hash(&aunt, &hash_so_far);
 
             hash_so_far = self.select(path_index, right_hash_pair, left_hash_pair)
         }
+        self.watch(&hash_so_far, "root");
         hash_so_far
+    }
+
+    pub fn get_root_from_merkle_proof<const PROOF_DEPTH: usize, const LEAF_SIZE_BYTES: usize>(
+        &mut self,
+        inclusion_proof: &MerkleInclusionProofVariable<PROOF_DEPTH, LEAF_SIZE_BYTES>,
+    ) -> Bytes32Variable {
+        let hashed_leaf = self.leaf_hash(&inclusion_proof.leaf.0);
+
+        self.get_root_from_merkle_proof_hashed_leaf::<PROOF_DEPTH>(
+            &inclusion_proof.aunts,
+            &inclusion_proof.path_indices,
+            hashed_leaf,
+        )
     }
 
     pub fn leaf_hash(&mut self, leaf: &[ByteVariable]) -> Bytes32Variable {

--- a/plonky2x/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/src/frontend/merkle/tendermint.rs
@@ -116,10 +116,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
     pub fn hash_leaves<const NB_LEAVES: usize, const LEAF_SIZE_BYTES: usize>(
         &mut self,
         leaves: &ArrayVariable<BytesVariable<LEAF_SIZE_BYTES>, NB_LEAVES>,
-    ) -> ArrayVariable<Bytes32Variable, NB_LEAVES>
-    where
-        <<L as PlonkParameters<D>>::Config as GenericConfig<D>>::Hasher: AlgebraicHasher<L::Field>,
-    {
+    ) -> ArrayVariable<Bytes32Variable, NB_LEAVES> {
         ArrayVariable::<Bytes32Variable, NB_LEAVES>::new(
             leaves
                 .as_vec()
@@ -133,10 +130,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
     pub fn get_root_from_hashed_leaves<const NB_ENABLED_LEAVES: usize, const NB_LEAVES: usize>(
         &mut self,
         leaf_hashes: &ArrayVariable<Bytes32Variable, NB_ENABLED_LEAVES>,
-    ) -> Bytes32Variable
-    where
-        <<L as PlonkParameters<D>>::Config as GenericConfig<D>>::Hasher: AlgebraicHasher<L::Field>,
-    {
+    ) -> Bytes32Variable {
         assert!(NB_ENABLED_LEAVES <= NB_LEAVES);
         assert!(NB_LEAVES.is_power_of_two());
 
@@ -176,10 +170,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
     >(
         &mut self,
         leaves: &ArrayVariable<BytesVariable<LEAF_SIZE_BYTES>, NB_ENABLED_LEAVES>,
-    ) -> Bytes32Variable
-    where
-        <<L as PlonkParameters<D>>::Config as GenericConfig<D>>::Hasher: AlgebraicHasher<L::Field>,
-    {
+    ) -> Bytes32Variable {
         let hashed_leaves = self.hash_leaves(leaves);
         self.get_root_from_hashed_leaves::<NB_ENABLED_LEAVES, NB_LEAVES>(&hashed_leaves)
     }


### PR DESCRIPTION
## Features
- Add function to generate merkle proof given a hashed leaf. This is useful for situations where the leaf hash requires a variable `sha256` hash.

## Misc
- Remove unnecessary function bounds for `AlgebraicHasher`