### PR TITLE
fix(Plonky2x): underscores in `Circuit` trait

### DIFF
--- a/plonky2x/src/backend/circuit/mod.rs
+++ b/plonky2x/src/backend/circuit/mod.rs
@@ -21,15 +21,17 @@ pub trait Circuit {
     fn define<L: PlonkParameters<D>, const D: usize>(builder: &mut CircuitBuilder<L, D>);
 
     /// Add generators to the generator_registry
+    #[allow(unused_variables)]
     fn add_generators<L: PlonkParameters<D>, const D: usize>(
-        _generator_registry: &mut WitnessGeneratorRegistry<L, D>,
+        generator_registry: &mut WitnessGeneratorRegistry<L, D>,
     ) where
         <<L as PlonkParameters<D>>::Config as GenericConfig<D>>::Hasher: AlgebraicHasher<L::Field>,
     {
     }
 
     /// Add gates to the gate_registry
-    fn add_gates<L: PlonkParameters<D>, const D: usize>(_gate_registry: &mut GateRegistry<L, D>)
+    #[allow(unused_variables)]
+    fn add_gates<L: PlonkParameters<D>, const D: usize>(gate_registry: &mut GateRegistry<L, D>)
     where
         <<L as PlonkParameters<D>>::Config as GenericConfig<D>>::Hasher: AlgebraicHasher<L::Field>,
     {


### PR DESCRIPTION
Currently, the `Circuit` trait definition has underscores under `gate_registry` and `generator_registry` because of unused variables warning of clippy. 

However, this is going to be a little misleading for users implementing the trait because the rust IDE autocomplete will also introduce these underscores. 

Instead, this PR just uses `#[allow(unused_variables)]`.