### PR TITLE
refactor(plonky2x): tendermint merkle tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+checksum = "0f2135563fb5c609d2b2b87c1e8ce7bc41b0b45430fa9661f457981503dd5bf0"
 dependencies = [
  "memchr",
 ]
@@ -177,7 +177,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-slice-cast"
@@ -419,9 +419,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.2"
+version = "4.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
 dependencies = [
  "anstream",
  "anstyle",
@@ -471,7 +471,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "curta"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/curta.git?branch=tamir/serialization#252099a28bc350b9c8a3d2a9c95fea44d577c304"
+source = "git+https://github.com/succinctlabs/curta.git#7927da115c6e3c8721c2b6c4993ad67cb6b6a837"
 dependencies = [
  "anyhow",
  "bincode",
@@ -738,7 +738,7 @@ source = "git+https://github.com/succinctlabs/curve25519-dalek.git?branch=featur
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -762,7 +762,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -773,7 +773,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1136,7 +1136,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.32",
+ "syn 2.0.37",
  "toml",
  "walkdir",
 ]
@@ -1154,7 +1154,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1180,7 +1180,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.32",
+ "syn 2.0.37",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -1517,7 +1517,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2065,9 +2065,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2294,7 +2294,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2360,7 +2360,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2389,9 +2389,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.8"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88eaac72ead1b9bd4ce747d577dbd2ad31fb0a56a9a20c611bf27bd1b97fbed"
+checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2403,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.8"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33bdcd446e9400b6ad9fc85b4aea68846c258b07c3efb994679ae82707b133f0"
+checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2540,7 +2540,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2578,7 +2578,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2618,7 +2618,7 @@ checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/mir-protocol/plonky2.git#d1c395ef7582ea810fcc5cabefe3e8a0b86b1156"
+source = "git+https://github.com/mir-protocol/plonky2.git#696377bae73a6b7f90d5d31c9ae7aea6e1b3dc52"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git#d1c395ef7582ea810fcc5cabefe3e8a0b86b1156"
+source = "git+https://github.com/mir-protocol/plonky2.git#696377bae73a6b7f90d5d31c9ae7aea6e1b3dc52"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -2666,7 +2666,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git#d1c395ef7582ea810fcc5cabefe3e8a0b86b1156"
+source = "git+https://github.com/mir-protocol/plonky2.git#696377bae73a6b7f90d5d31c9ae7aea6e1b3dc52"
 dependencies = [
  "rayon",
 ]
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git#d1c395ef7582ea810fcc5cabefe3e8a0b86b1156"
+source = "git+https://github.com/mir-protocol/plonky2.git#696377bae73a6b7f90d5d31c9ae7aea6e1b3dc52"
 
 [[package]]
 name = "plonky2x"
@@ -2719,7 +2719,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2741,7 +2741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2810,9 +2810,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -3082,7 +3082,7 @@ checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.4",
+ "rustls-webpki 0.101.5",
  "sct",
 ]
 
@@ -3097,9 +3097,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.2"
+version = "0.100.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
+checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
 dependencies = [
  "ring",
  "untrusted",
@@ -3107,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
+version = "0.101.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
 dependencies = [
  "ring",
  "untrusted",
@@ -3292,14 +3292,14 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -3362,7 +3362,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3552,7 +3552,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3603,9 +3603,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3668,7 +3668,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3750,7 +3750,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3862,7 +3862,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3912,9 +3912,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uint"
@@ -3936,9 +3936,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -4071,7 +4071,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -4105,7 +4105,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4132,7 +4132,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
- "rustls-webpki 0.100.2",
+ "rustls-webpki 0.100.3",
 ]
 
 [[package]]

--- a/plonky2x/Cargo.toml
+++ b/plonky2x/Cargo.toml
@@ -14,13 +14,13 @@ ci = []
 
 [dependencies]
 plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", default-features = false }
-curta = { git = "https://github.com/succinctlabs/curta.git", branch = "tamir/serialization" }
+curta = { git = "https://github.com/succinctlabs/curta.git" }
 plonky2x-derive = { path = "../plonky2x-derive" }
 
 num = { version = "0.4", default-features = false }
 sha2 = "0.10.7"
 curve25519-dalek = { git = "https://github.com/succinctlabs/curve25519-dalek.git", branch = "feature/edwards-point-getters" }
-ff = {package="ff" , version="0.13", features = ["derive"]}
+ff = { package = "ff", version = "0.13", features = ["derive"] }
 
 ethers = { version = "2.0" }
 

--- a/plonky2x/src/frontend/hash/keccak/mod.rs
+++ b/plonky2x/src/frontend/hash/keccak/mod.rs
@@ -18,7 +18,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
             _phantom: PhantomData::<L>,
         };
         let output = generator.output;
-        self.add_simple_generator(generator.clone());
+        self.add_simple_generator(generator);
         output
     }
 
@@ -33,7 +33,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
             length: Some(length),
             _phantom: PhantomData::<L>,
         };
-        self.add_simple_generator(generator.clone());
+        self.add_simple_generator(generator);
         generator.output
     }
 }

--- a/plonky2x/src/frontend/hash/keccak/mod.rs
+++ b/plonky2x/src/frontend/hash/keccak/mod.rs
@@ -18,7 +18,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
             _phantom: PhantomData::<L>,
         };
         let output = generator.output;
-        self.add_simple_generator(generator);
+        self.add_simple_generator(generator.clone());
         output
     }
 
@@ -33,7 +33,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
             length: Some(length),
             _phantom: PhantomData::<L>,
         };
-        self.add_simple_generator(generator);
+        self.add_simple_generator(generator.clone());
         generator.output
     }
 }

--- a/plonky2x/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/src/frontend/merkle/tendermint.rs
@@ -151,11 +151,14 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
 
     pub fn compute_root_from_leaves<const NB_LEAVES: usize, const LEAF_SIZE_BYTES: usize>(
         &mut self,
-        leaves: ArrayVariable<BytesVariable<LEAF_SIZE_BYTES>, NB_LEAVES>,
-        leaves_enabled: ArrayVariable<BoolVariable, NB_LEAVES>,
+        leaves: Vec<BytesVariable<LEAF_SIZE_BYTES>>,
+        leaves_enabled: Vec<BoolVariable>,
     ) -> Bytes32Variable {
-        let hashed_leaves = self.hash_leaves::<LEAF_SIZE_BYTES>(leaves.as_vec());
-        self.get_root_from_hashed_leaves::<NB_LEAVES>(hashed_leaves, leaves_enabled.as_vec())
+        assert!(NB_LEAVES == leaves.len());
+        assert!(NB_LEAVES == leaves_enabled.len());
+
+        let hashed_leaves = self.hash_leaves::<LEAF_SIZE_BYTES>(leaves.to_vec());
+        self.get_root_from_hashed_leaves::<NB_LEAVES>(hashed_leaves, leaves_enabled.to_vec())
     }
 }
 

--- a/plonky2x/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/src/frontend/merkle/tendermint.rs
@@ -113,7 +113,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
 
     pub fn hash_leaves<const LEAF_SIZE_BYTES: usize>(
         &mut self,
-        leaves: &Vec<BytesVariable<LEAF_SIZE_BYTES>>,
+        leaves: Vec<BytesVariable<LEAF_SIZE_BYTES>>,
     ) -> Vec<Bytes32Variable> {
         leaves
             .iter()
@@ -123,8 +123,8 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
 
     pub fn get_root_from_hashed_leaves<const NB_LEAVES: usize>(
         &mut self,
-        leaf_hashes: &Vec<Bytes32Variable>,
-        leaves_enabled: &Vec<BoolVariable>,
+        leaf_hashes: Vec<Bytes32Variable>,
+        leaves_enabled: Vec<BoolVariable>,
     ) -> Bytes32Variable {
         assert!(NB_LEAVES.is_power_of_two());
 
@@ -149,14 +149,14 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
 
     pub fn compute_root_from_leaves<const NB_LEAVES: usize, const LEAF_SIZE_BYTES: usize>(
         &mut self,
-        leaves: &Vec<BytesVariable<LEAF_SIZE_BYTES>>,
-        leaves_enabled: &Vec<BoolVariable>,
+        leaves: Vec<BytesVariable<LEAF_SIZE_BYTES>>,
+        leaves_enabled: Vec<BoolVariable>,
     ) -> Bytes32Variable {
         // TODO: Remove, this is just for debugging.
         assert_eq!(leaves.len(), NB_LEAVES);
 
         let hashed_leaves = self.hash_leaves::<LEAF_SIZE_BYTES>(leaves);
-        self.get_root_from_hashed_leaves::<NB_LEAVES>(&hashed_leaves, leaves_enabled)
+        self.get_root_from_hashed_leaves::<NB_LEAVES>(hashed_leaves, leaves_enabled)
     }
 }
 
@@ -187,7 +187,7 @@ mod tests {
 
         let leaves = builder.read::<ArrayVariable<BytesVariable<48>, 32>>();
         let enabled = builder.read::<ArrayVariable<BoolVariable, 32>>();
-        let root = builder.compute_root_from_leaves::<32, 48>(&leaves.as_vec(), &enabled.as_vec());
+        let root = builder.compute_root_from_leaves::<32, 48>(leaves.as_vec(), enabled.as_vec());
         builder.write::<Bytes32Variable>(root);
         let circuit = builder.build();
         circuit.test_default_serializers();

--- a/plonky2x/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/src/frontend/merkle/tendermint.rs
@@ -1,4 +1,3 @@
-use ethers::types::H256;
 use itertools::Itertools;
 
 use super::tree::MerkleInclusionProofVariable;

--- a/plonky2x/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/src/frontend/merkle/tendermint.rs
@@ -121,13 +121,14 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
             .collect_vec()
     }
 
-    // leaf_hashes and leaves_enabled should be of size NB_LEAVES.
     pub fn get_root_from_hashed_leaves<const NB_LEAVES: usize>(
         &mut self,
         leaf_hashes: Vec<Bytes32Variable>,
         leaves_enabled: Vec<BoolVariable>,
     ) -> Bytes32Variable {
         assert!(NB_LEAVES.is_power_of_two());
+        assert!(leaf_hashes.len() == NB_LEAVES);
+        assert!(leaves_enabled.len() == NB_LEAVES);
 
         // Hash each of the validators to get their corresponding leaf hash.
         let mut current_nodes = leaf_hashes.clone();

--- a/plonky2x/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/src/frontend/merkle/tendermint.rs
@@ -189,7 +189,7 @@ mod tests {
 
         let leaves = builder.read::<ArrayVariable<BytesVariable<48>, 32>>();
         let enabled = builder.read::<ArrayVariable<BoolVariable, 32>>();
-        let root = builder.compute_root_from_leaves::<32, 48>(leaves, enabled);
+        let root = builder.compute_root_from_leaves::<32, 48>(leaves.as_vec(), enabled.as_vec());
         builder.write::<Bytes32Variable>(root);
         let circuit = builder.build();
         circuit.test_default_serializers();


### PR DESCRIPTION
## Changes
- Remove `NB_LEAVES_ENABLED` as const generic, for most circuits, `NB_LEAVES_ENABLED` will be variable and it's more idiomatic to pass in a `leaves_enabled` array.
- Refactor tests for `tendermint` to follow new `CircuitBuilder` format.
- Update `curta` branch to `main`