### PR TITLE
feat(plonky2x): sha256 curta async hint

### DIFF
--- a/plonky2x/src/backend/circuit/serialization/hints.rs
+++ b/plonky2x/src/backend/circuit/serialization/hints.rs
@@ -45,6 +45,7 @@ use plonky2::util::serialization::{Buffer, IoResult, Read, WitnessGeneratorSeria
 use super::registry::{SerializationRegistry, Serializer};
 use super::PlonkParameters;
 use crate::frontend::builder::watch::WatchGenerator;
+use crate::frontend::curta::hash::sha::sha256::hint::Sha256ProofHint;
 use crate::frontend::ecc::ed25519::field::ed25519_base::Ed25519Base;
 use crate::frontend::eth::beacon::generators::{
     BeaconAllWithdrawalsHint, BeaconBalanceBatchWitnessHint, BeaconBalanceGenerator,
@@ -70,6 +71,7 @@ use crate::frontend::hint::asynchronous::hint::AsyncHint;
 use crate::frontend::hint::asynchronous::serializer::AsyncHintSerializer;
 use crate::frontend::hint::simple::hint::Hint;
 use crate::frontend::hint::simple::serializer::SimpleHintSerializer;
+use crate::frontend::hint::synchronous::Async;
 use crate::frontend::num::biguint::BigUintDivRemGenerator;
 use crate::frontend::num::nonnative::nonnative::{
     NonNativeAdditionGenerator, NonNativeInverseGenerator, NonNativeMultipleAddsGenerator,
@@ -397,13 +399,17 @@ where
         r.register_hint::<BeaconExecutionPayloadHint>();
         r.register_hint::<BeaconHeaderHint>();
         r.register_hint::<BeaconAllWithdrawalsHint>();
+        r.register_hint::<Sha256ProofHint<L, D>>();
+
+        r.register_async_hint::<EthStorageProofHint<L, D>>();
+        r.register_async_hint::<BeaconValidatorsHint>();
+        r.register_async_hint::<Async<Sha256ProofHint<L, D>>>();
 
         register_powers_of_two!(r, BeaconBalanceBatchWitnessHint);
         register_powers_of_two!(r, BeaconPartialBalancesHint);
         register_powers_of_two!(r, BeaconValidatorBatchHint);
         register_powers_of_two!(r, BeaconPartialValidatorsHint);
         register_powers_of_two!(r, CompressedBeaconValidatorBatchHint);
-        r.register_async_hint::<EthStorageProofHint<L, D>>();
         let id = NonNativeAdditionGenerator::<L::Field, D, Ed25519Base>::default().id();
         r.register_simple::<NonNativeAdditionGenerator<L::Field, D, Ed25519Base>>(id);
 
@@ -434,8 +440,6 @@ where
 
         let id = MulCubicGenerator::<L::Field, D>::id();
         r.register_simple::<MulCubicGenerator<L::Field, D>>(id);
-
-        r.register_async_hint::<BeaconValidatorsHint>();
 
         let blake2b_hint_generator_id = BLAKE2BHintGenerator::id();
         r.register_simple::<BLAKE2BHintGenerator>(blake2b_hint_generator_id);

--- a/plonky2x/src/frontend/curta/hash/sha/sha256/builder.rs
+++ b/plonky2x/src/frontend/curta/hash/sha/sha256/builder.rs
@@ -53,21 +53,26 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
 
         self.verify_stark_proof(&config, &stark, &proof, &public_input_variable);
 
-        let public_w = outputs.read_vec::<[Variable; 4]>(self, public_sha_targets.public_w.len());
+        let public_w = outputs.read_exact(self, public_sha_targets.public_w.len() * 4);
 
-        let hash_state =
-            outputs.read_vec::<[Variable; 4]>(self, public_sha_targets.hash_state.len());
+        let hash_state = outputs.read_exact(self, public_sha_targets.hash_state.len() * 4);
 
-        for (target, variable) in public_sha_targets.public_w.iter().zip(public_w.iter()) {
-            for (x, y) in target.iter().zip(variable.iter()) {
-                self.api.connect(*x, y.0);
-            }
+        for (target, variable) in public_sha_targets
+            .public_w
+            .iter()
+            .flatten()
+            .zip(public_w.iter())
+        {
+            self.api.connect(*target, variable.0);
         }
 
-        for (target, variable) in public_sha_targets.hash_state.iter().zip(hash_state.iter()) {
-            for (x, y) in target.iter().zip(variable.iter()) {
-                self.api.connect(*x, y.0);
-            }
+        for (target, variable) in public_sha_targets
+            .hash_state
+            .iter()
+            .flatten()
+            .zip(hash_state.iter())
+        {
+            self.api.connect(*target, variable.0);
         }
     }
 }

--- a/plonky2x/src/frontend/curta/hash/sha/sha256/builder.rs
+++ b/plonky2x/src/frontend/curta/hash/sha/sha256/builder.rs
@@ -5,6 +5,7 @@ use curta::chip::hash::sha::sha256::generator::SHA256StarkData;
 use curta::chip::hash::sha::sha256::SHA256PublicData;
 
 use super::hint::Sha256ProofHint;
+use crate::frontend::hint::synchronous::Async;
 use crate::prelude::{PlonkParameters, *};
 
 impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
@@ -37,7 +38,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
 
         input_stream.write_slice(&chunk_sizes);
 
-        let outputs = self.hint(input_stream, hint);
+        let outputs = self.async_hint(input_stream, Async(hint));
 
         let proof = outputs.read_stark_proof(self, &stark, &config);
 

--- a/plonky2x/src/frontend/curta/hash/sha/sha256/builder.rs
+++ b/plonky2x/src/frontend/curta/hash/sha/sha256/builder.rs
@@ -1,0 +1,73 @@
+use core::marker::PhantomData;
+
+use curta::chip::hash::sha::sha256::builder_gadget::SHA256BuilderGadget;
+use curta::chip::hash::sha::sha256::generator::SHA256StarkData;
+use curta::chip::hash::sha::sha256::SHA256PublicData;
+
+use super::hint::Sha256ProofHint;
+use crate::prelude::{PlonkParameters, *};
+
+impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
+    pub fn constrain_sha256_gadget(
+        &mut self,
+        gadget: SHA256BuilderGadget<L::Field, L::CubicParams, D>,
+    ) {
+        let mut input_stream = VariableStream::new();
+
+        let hint = Sha256ProofHint::<L, D> {
+            num_messages: gadget.chunk_sizes.len(),
+            _phantom: PhantomData,
+        };
+
+        let SHA256StarkData { stark, config, .. } = Sha256ProofHint::<L, D>::stark_data();
+
+        let padded_messages = gadget
+            .padded_messages
+            .iter()
+            .map(|x| Variable(*x))
+            .collect::<Vec<_>>();
+
+        let chunk_sizes = gadget
+            .chunk_sizes
+            .iter()
+            .map(|x| self.constant::<Variable>(L::Field::from_canonical_usize(*x)))
+            .collect::<Vec<_>>();
+
+        input_stream.write_slice(&padded_messages);
+
+        input_stream.write_slice(&chunk_sizes);
+
+        let outputs = self.hint(input_stream, hint);
+
+        let proof = outputs.read_stark_proof(self, &stark, &config);
+
+        let public_sha_targets =
+            SHA256PublicData::add_virtual(&mut self.api, &gadget.digests, &gadget.chunk_sizes);
+
+        let public_input_target = public_sha_targets.public_input_targets(&mut self.api);
+
+        let public_input_variable = public_input_target
+            .iter()
+            .map(|target| Variable(*target))
+            .collect::<Vec<_>>();
+
+        self.verify_stark_proof(&config, &stark, &proof, &public_input_variable);
+
+        let public_w = outputs.read_vec::<[Variable; 4]>(self, public_sha_targets.public_w.len());
+
+        let hash_state =
+            outputs.read_vec::<[Variable; 4]>(self, public_sha_targets.hash_state.len());
+
+        for (target, variable) in public_sha_targets.public_w.iter().zip(public_w.iter()) {
+            for (x, y) in target.iter().zip(variable.iter()) {
+                self.api.connect(*x, y.0);
+            }
+        }
+
+        for (target, variable) in public_sha_targets.hash_state.iter().zip(hash_state.iter()) {
+            for (x, y) in target.iter().zip(variable.iter()) {
+                self.api.connect(*x, y.0);
+            }
+        }
+    }
+}

--- a/plonky2x/src/frontend/curta/hash/sha/sha256/hint.rs
+++ b/plonky2x/src/frontend/curta/hash/sha/sha256/hint.rs
@@ -1,0 +1,119 @@
+use core::marker::PhantomData;
+
+use curta::chip::builder::AirBuilder;
+use curta::chip::hash::sha::sha256::generator::{SHA256AirParameters, SHA256StarkData};
+use curta::chip::hash::sha::sha256::SHA256PublicData;
+use curta::chip::trace::generator::ArithmeticGenerator;
+use curta::plonky2::stark::config::StarkyConfig;
+use curta::plonky2::stark::prover::StarkyProver;
+use curta::plonky2::stark::Starky;
+use plonky2::field::types::PrimeField64;
+use serde::{Deserialize, Serialize};
+
+use crate::frontend::hint::simple::hint::Hint;
+use crate::prelude::{PlonkParameters, ValueStream, *};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Sha256ProofHint<L: PlonkParameters<D>, const D: usize> {
+    pub num_messages: usize,
+    pub _phantom: PhantomData<L>,
+}
+
+impl<L: PlonkParameters<D>, const D: usize> Hint<L, D> for Sha256ProofHint<L, D> {
+    fn hint(&self, input_stream: &mut ValueStream<L, D>, output_stream: &mut ValueStream<L, D>) {
+        let SHA256StarkData {
+            stark,
+            table,
+            trace_generator,
+            config,
+            gadget,
+        } = Self::stark_data();
+
+        let padded_messages = input_stream
+            .read_exact(1024 * 64)
+            .iter()
+            .map(|b| b.to_canonical_u64() as u8)
+            .collect::<Vec<_>>();
+
+        let chunk_sizes = input_stream.read_vec::<Variable>(self.num_messages);
+
+        let message_chunks = chunk_sizes.iter().scan(0, |idx, size| {
+            let size = size.to_canonical_u64() as usize;
+            let chunk = padded_messages[*idx..*idx + 64 * size].to_vec();
+            *idx += 64 * size;
+            Some(chunk)
+        });
+
+        // Write trace values
+        let num_rows = 1 << 16;
+        let writer = trace_generator.new_writer();
+        table.write_table_entries(&writer);
+        let sha_public_values = gadget.write(message_chunks, &writer);
+        for i in 0..num_rows {
+            writer.write_row_instructions(&trace_generator.air_data, i);
+        }
+
+        let public_inputs: Vec<_> = writer.public().unwrap().clone();
+
+        let proof = StarkyProver::<L::Field, L::CurtaConfig, D>::prove(
+            &config,
+            &stark,
+            &trace_generator,
+            &public_inputs,
+        )
+        .unwrap();
+
+        output_stream.write_stark_proof(proof);
+
+        let SHA256PublicData {
+            public_w,
+            hash_state,
+            ..
+        } = sha_public_values;
+
+        public_w
+            .into_iter()
+            .for_each(|w| output_stream.write_value::<[Variable; 4]>(w));
+
+        hash_state
+            .into_iter()
+            .for_each(|h| output_stream.write_value::<[Variable; 4]>(h));
+    }
+}
+
+impl<L: PlonkParameters<D>, const D: usize> Sha256ProofHint<L, D> {
+    pub fn stark_data() -> SHA256StarkData<L::Field, L::CubicParams, L::CurtaConfig, D> {
+        let mut air_builder = AirBuilder::<SHA256AirParameters<L::Field, L::CubicParams>>::new();
+        let clk = air_builder.clock();
+
+        let (mut operations, table) = air_builder.byte_operations();
+
+        let mut bus = air_builder.new_bus();
+        let channel_idx = bus.new_channel(&mut air_builder);
+
+        let gadget =
+            air_builder.process_sha_256_batch(&clk, &mut bus, channel_idx, &mut operations);
+
+        air_builder.register_byte_lookup(operations, &table);
+        air_builder.constrain_bus(bus);
+
+        let (air, trace_data) = air_builder.build();
+
+        let num_rows = 1 << 16;
+        let stark = Starky::new(air);
+        let config = StarkyConfig::<L::CurtaConfig, D>::standard_fast_config(num_rows);
+
+        let trace_generator =
+            ArithmeticGenerator::<SHA256AirParameters<L::Field, L::CubicParams>>::new(
+                trace_data, num_rows,
+            );
+
+        SHA256StarkData {
+            stark,
+            table,
+            trace_generator,
+            config,
+            gadget,
+        }
+    }
+}

--- a/plonky2x/src/frontend/curta/hash/sha/sha256/hint.rs
+++ b/plonky2x/src/frontend/curta/hash/sha/sha256/hint.rs
@@ -44,7 +44,7 @@ impl<L: PlonkParameters<D>, const D: usize> Hint<L, D> for Sha256ProofHint<L, D>
             Some(chunk)
         });
 
-        // Write trace values
+        // Write trace values.
         let num_rows = 1 << 16;
         let writer = trace_generator.new_writer();
         table.write_table_entries(&writer);

--- a/plonky2x/src/frontend/curta/hash/sha/sha256/hint.rs
+++ b/plonky2x/src/frontend/curta/hash/sha/sha256/hint.rs
@@ -22,8 +22,6 @@ pub struct Sha256ProofHint<L: PlonkParameters<D>, const D: usize> {
 
 impl<L: PlonkParameters<D>, const D: usize> Hint<L, D> for Sha256ProofHint<L, D> {
     fn hint(&self, input_stream: &mut ValueStream<L, D>, output_stream: &mut ValueStream<L, D>) {
-        debug!("Beginning hint!");
-
         let SHA256StarkData {
             stark,
             table,
@@ -47,8 +45,6 @@ impl<L: PlonkParameters<D>, const D: usize> Hint<L, D> for Sha256ProofHint<L, D>
             Some(chunk)
         });
 
-        debug!("Read in values from input stream (hint-1)!");
-
         // Write trace values
         let num_rows = 1 << 16;
         let writer = trace_generator.new_writer();
@@ -68,11 +64,7 @@ impl<L: PlonkParameters<D>, const D: usize> Hint<L, D> for Sha256ProofHint<L, D>
         )
         .unwrap();
 
-        debug!("Created stark proof (hint-2)!");
-
         output_stream.write_stark_proof(proof);
-
-        debug!("Wrote stark proof (hint-3)!");
 
         let SHA256PublicData {
             public_w,
@@ -82,11 +74,7 @@ impl<L: PlonkParameters<D>, const D: usize> Hint<L, D> for Sha256ProofHint<L, D>
 
         output_stream.write_slice(&public_w.into_iter().flatten().collect::<Vec<_>>());
 
-        debug!("Wrote first slice (hint-4)!");
-
         output_stream.write_slice(&hash_state.into_iter().flatten().collect::<Vec<_>>());
-
-        debug!("Stark proof complete (hint-5)!");
     }
 }
 

--- a/plonky2x/src/frontend/curta/hash/sha/sha256/hint.rs
+++ b/plonky2x/src/frontend/curta/hash/sha/sha256/hint.rs
@@ -72,6 +72,8 @@ impl<L: PlonkParameters<D>, const D: usize> Hint<L, D> for Sha256ProofHint<L, D>
 
         output_stream.write_stark_proof(proof);
 
+        debug!("Wrote stark proof (hint-3)!");
+
         let SHA256PublicData {
             public_w,
             hash_state,
@@ -80,9 +82,11 @@ impl<L: PlonkParameters<D>, const D: usize> Hint<L, D> for Sha256ProofHint<L, D>
 
         output_stream.write_slice(&public_w.into_iter().flatten().collect::<Vec<_>>());
 
+        debug!("Wrote first slice (hint-4)!");
+
         output_stream.write_slice(&hash_state.into_iter().flatten().collect::<Vec<_>>());
 
-        debug!("Stark proof complete (hint-3)!");
+        debug!("Stark proof complete (hint-5)!");
     }
 }
 

--- a/plonky2x/src/frontend/curta/hash/sha/sha256/hint.rs
+++ b/plonky2x/src/frontend/curta/hash/sha/sha256/hint.rs
@@ -7,7 +7,6 @@ use curta::chip::trace::generator::ArithmeticGenerator;
 use curta::plonky2::stark::config::StarkyConfig;
 use curta::plonky2::stark::prover::StarkyProver;
 use curta::plonky2::stark::Starky;
-use log::debug;
 use plonky2::field::types::PrimeField64;
 use serde::{Deserialize, Serialize};
 

--- a/plonky2x/src/frontend/curta/hash/sha/sha256/mod.rs
+++ b/plonky2x/src/frontend/curta/hash/sha/sha256/mod.rs
@@ -1,1 +1,2 @@
-
+pub mod builder;
+pub mod hint;

--- a/plonky2x/src/frontend/hash/sha/sha256_curta.rs
+++ b/plonky2x/src/frontend/hash/sha/sha256_curta.rs
@@ -389,18 +389,18 @@ mod tests {
             .map(|_| short_msg_bytes.clone())
             .collect::<Vec<_>>();
 
-        // // Requires 3 chunks each.
-        // let long_msg = [1u8; 128];
-        // let long_msg_bytes = long_msg
-        //     .iter()
-        //     .map(|b| builder.constant::<ByteVariable>(*b))
-        //     .collect::<Vec<_>>();
+        // Requires 3 chunks each.
+        let long_msg = [1u8; 128];
+        let long_msg_bytes = long_msg
+            .iter()
+            .map(|b| builder.constant::<ByteVariable>(*b))
+            .collect::<Vec<_>>();
 
-        // msgs.extend(
-        //     (0..2048)
-        //         .map(|_| long_msg_bytes.clone())
-        //         .collect::<Vec<_>>(),
-        // );
+        msgs.extend(
+            (0..2048)
+                .map(|_| long_msg_bytes.clone())
+                .collect::<Vec<_>>(),
+        );
 
         let mut builder = CircuitBuilder::<L, D>::new();
         let digests = msgs

--- a/plonky2x/src/frontend/hash/sha/sha256_curta.rs
+++ b/plonky2x/src/frontend/hash/sha/sha256_curta.rs
@@ -315,7 +315,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
                 rq_idx += 1;
             }
 
-            self.api.constrain_sha256_gadget::<L::CurtaConfig>(gadget);
+            self.constrain_sha256_gadget(gadget);
         }
     }
 }
@@ -352,18 +352,18 @@ mod tests {
         builder.assert_is_equal(result, expected_digest);
 
         let circuit = builder.build();
-        let gate_serializer = GateRegistry::<L, D>::new();
-        let generator_serializer = HintRegistry::<L, D>::new();
-        let bytes = circuit
-            .serialize(&gate_serializer, &generator_serializer)
-            .unwrap();
-        let circuit =
-            CircuitBuild::<L, D>::deserialize(&bytes, &gate_serializer, &generator_serializer)
-                .unwrap();
+        // let gate_serializer = GateRegistry::<L, D>::new();
+        // let generator_serializer = HintRegistry::<L, D>::new();
+        // let bytes = circuit
+        //     .serialize(&gate_serializer, &generator_serializer)
+        //     .unwrap();
+        // let circuit =
+        //     CircuitBuild::<L, D>::deserialize(&bytes, &gate_serializer, &generator_serializer)
+        //         .unwrap();
         let input = circuit.input();
         let (proof, output) = circuit.prove(&input);
         circuit.verify(&proof, &input, &output);
-        circuit.test_default_serializers();
+        // circuit.test_default_serializers();
     }
 
     #[test]

--- a/plonky2x/src/frontend/hash/sha/sha256_curta.rs
+++ b/plonky2x/src/frontend/hash/sha/sha256_curta.rs
@@ -327,7 +327,9 @@ mod tests {
     use crate::backend::circuit::{CircuitBuild, DefaultParameters};
     use crate::frontend::uint::uint32::U32Variable;
     use crate::frontend::vars::Bytes32Variable;
-    use crate::prelude::{ByteVariable, BytesVariable, CircuitBuilder, GateRegistry, HintRegistry, DefaultBuilder};
+    use crate::prelude::{
+        ByteVariable, BytesVariable, CircuitBuilder, DefaultBuilder, GateRegistry, HintRegistry,
+    };
     use crate::utils::{bytes, bytes32};
 
     type L = DefaultParameters;

--- a/plonky2x/src/frontend/hash/sha/sha256_curta.rs
+++ b/plonky2x/src/frontend/hash/sha/sha256_curta.rs
@@ -327,7 +327,7 @@ mod tests {
     use crate::backend::circuit::{CircuitBuild, DefaultParameters};
     use crate::frontend::uint::uint32::U32Variable;
     use crate::frontend::vars::Bytes32Variable;
-    use crate::prelude::{ByteVariable, BytesVariable, CircuitBuilder, GateRegistry, HintRegistry};
+    use crate::prelude::{ByteVariable, BytesVariable, CircuitBuilder, GateRegistry, HintRegistry, DefaultBuilder};
     use crate::utils::{bytes, bytes32};
 
     type L = DefaultParameters;
@@ -364,6 +364,52 @@ mod tests {
         let (proof, output) = circuit.prove(&input);
         circuit.verify(&proof, &input, &output);
         // circuit.test_default_serializers();
+    }
+
+    #[test]
+    #[cfg_attr(feature = "ci", ignore)]
+    fn test_curta_allocation() {
+        env::set_var("RUST_LOG", "debug");
+        env_logger::try_init().unwrap_or_default();
+        dotenv::dotenv().ok();
+
+        let mut builder = DefaultBuilder::new();
+
+        // Requires 2 chunks each.
+        let short_msg = [1u8; 56];
+
+        let short_msg_bytes = short_msg
+            .iter()
+            .map(|b| builder.constant::<ByteVariable>(*b))
+            .collect::<Vec<_>>();
+
+        let mut msgs = (0..1024)
+            .map(|_| short_msg_bytes.clone())
+            .collect::<Vec<_>>();
+
+        // // Requires 3 chunks each.
+        // let long_msg = [1u8; 128];
+        // let long_msg_bytes = long_msg
+        //     .iter()
+        //     .map(|b| builder.constant::<ByteVariable>(*b))
+        //     .collect::<Vec<_>>();
+
+        // msgs.extend(
+        //     (0..2048)
+        //         .map(|_| long_msg_bytes.clone())
+        //         .collect::<Vec<_>>(),
+        // );
+
+        let mut builder = CircuitBuilder::<L, D>::new();
+        let digests = msgs
+            .iter()
+            .map(|msg| builder.curta_sha256(msg))
+            .collect::<Vec<_>>();
+
+        let circuit = builder.build();
+        let input = circuit.input();
+        let (proof, output) = circuit.prove(&input);
+        circuit.verify(&proof, &input, &output);
     }
 
     #[test]

--- a/plonky2x/src/frontend/hash/sha/sha256_curta.rs
+++ b/plonky2x/src/frontend/hash/sha/sha256_curta.rs
@@ -354,18 +354,18 @@ mod tests {
         builder.assert_is_equal(result, expected_digest);
 
         let circuit = builder.build();
-        // let gate_serializer = GateRegistry::<L, D>::new();
-        // let generator_serializer = HintRegistry::<L, D>::new();
-        // let bytes = circuit
-        //     .serialize(&gate_serializer, &generator_serializer)
-        //     .unwrap();
-        // let circuit =
-        //     CircuitBuild::<L, D>::deserialize(&bytes, &gate_serializer, &generator_serializer)
-        //         .unwrap();
+        let gate_serializer = GateRegistry::<L, D>::new();
+        let generator_serializer = HintRegistry::<L, D>::new();
+        let bytes = circuit
+            .serialize(&gate_serializer, &generator_serializer)
+            .unwrap();
+        let circuit =
+            CircuitBuild::<L, D>::deserialize(&bytes, &gate_serializer, &generator_serializer)
+                .unwrap();
         let input = circuit.input();
         let (proof, output) = circuit.prove(&input);
         circuit.verify(&proof, &input, &output);
-        // circuit.test_default_serializers();
+        circuit.test_default_serializers();
     }
 
     #[test]
@@ -403,7 +403,7 @@ mod tests {
         );
 
         let mut builder = CircuitBuilder::<L, D>::new();
-        let digests = msgs
+        let _ = msgs
             .iter()
             .map(|msg| builder.curta_sha256(msg))
             .collect::<Vec<_>>();

--- a/plonky2x/src/frontend/vars/stream.rs
+++ b/plonky2x/src/frontend/vars/stream.rs
@@ -153,6 +153,10 @@ impl<L: PlonkParameters<D>, const D: usize> ValueStream<L, D> {
         self.0.read_exact(len)
     }
 
+    pub fn read_vec<V: CircuitVariable>(&mut self, len: usize) -> Vec<V::ValueType<L::Field>> {
+        (0..len).map(|_| self.read_value::<V>()).collect()
+    }
+
     pub fn write_slice(&mut self, values: &[L::Field]) {
         self.0.write_slice(values);
     }


### PR DESCRIPTION
## Overview
- Add `async_hint` for `curta_sha256` to `succinctx`, enables `sha256` gadgets to be run async.
- ~2x speedup over sync `sha256` with 10 gadgets, takes advantage of unallocated cores.