### PR TITLE
refactor: `CircuitVariable`

### DIFF
--- a/plonky2x-derive/src/elements.rs
+++ b/plonky2x-derive/src/elements.rs
@@ -6,7 +6,7 @@ use crate::StructData;
 pub(crate) fn elements(data: &StructData) -> TokenStream {
     let recurse = data.fields.iter().map(|(name, ty, _)| {
         quote! {
-            elements_vec.extend_from_slice(<#ty as CircuitVariable>::elements(&value.#name).as_slice());
+            elements_vec.extend_from_slice(<#ty as CircuitVariable>::elements(value.#name).as_slice());
 
         }
     });
@@ -37,7 +37,7 @@ pub(crate) fn from_elements(data: &StructData) -> TokenStream {
         let mut cv_derive_impl_index = 0;
         #(#value_recurse)*
 
-        Self {
+        Self::ValueType::<F> {
             #(#instant_recurse)*
         }
     }
@@ -52,7 +52,7 @@ pub(crate) fn nb_elements(data: &StructData) -> TokenStream {
 
     quote! {
         let mut res = 0;
-        #(#value_recurse)*
+        // #(#value_recurse)*
 
         res
     }

--- a/plonky2x-derive/src/elements.rs
+++ b/plonky2x-derive/src/elements.rs
@@ -44,7 +44,7 @@ pub(crate) fn from_elements(data: &StructData) -> TokenStream {
 }
 
 pub(crate) fn nb_elements(data: &StructData) -> TokenStream {
-    let _value_recurse = data.fields.iter().map(|(_, ty, _)| {
+    let value_recurse = data.fields.iter().map(|(_, ty, _)| {
         quote! {
             res += <#ty as CircuitVariable>::nb_elements();
         }
@@ -52,7 +52,7 @@ pub(crate) fn nb_elements(data: &StructData) -> TokenStream {
 
     quote! {
         let mut res = 0;
-        // #(#value_recurse)*
+        #(#value_recurse)*
 
         res
     }

--- a/plonky2x-derive/src/elements.rs
+++ b/plonky2x-derive/src/elements.rs
@@ -44,7 +44,7 @@ pub(crate) fn from_elements(data: &StructData) -> TokenStream {
 }
 
 pub(crate) fn nb_elements(data: &StructData) -> TokenStream {
-    let value_recurse = data.fields.iter().map(|(_, ty, _)| {
+    let _value_recurse = data.fields.iter().map(|(_, ty, _)| {
         quote! {
             res += <#ty as CircuitVariable>::nb_elements();
         }

--- a/plonky2x-derive/src/elements.rs
+++ b/plonky2x-derive/src/elements.rs
@@ -52,6 +52,7 @@ pub(crate) fn nb_elements(data: &StructData) -> TokenStream {
 
     quote! {
         let mut res = 0;
+
         #(#value_recurse)*
 
         res

--- a/plonky2x-derive/src/elements.rs
+++ b/plonky2x-derive/src/elements.rs
@@ -1,0 +1,59 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::StructData;
+
+pub(crate) fn elements(data: &StructData) -> TokenStream {
+    let recurse = data.fields.iter().map(|(name, ty, _)| {
+        quote! {
+            elements_vec.extend_from_slice(<#ty as CircuitVariable>::elements(&value.#name).as_slice());
+
+        }
+    });
+    quote! {
+        let mut elements_vec = vec![];
+
+        #(#recurse)*
+
+        elements_vec
+    }
+}
+
+pub(crate) fn from_elements(data: &StructData) -> TokenStream {
+    let value_recurse = data.fields.iter().map(|(name, ty, _)| {
+        quote! {
+            let cv_derive_imple_size = <#ty as CircuitVariable>::nb_elements();
+            let #name = <#ty as CircuitVariable>::from_elements(&elements[cv_derive_impl_index..cv_derive_impl_index+cv_derive_imple_size]);
+            cv_derive_impl_index += cv_derive_imple_size;
+        }
+    });
+
+    let instant_recurse = data.fields.iter().map(|(name, _, _)| {
+        quote! {
+            #name,
+        }
+    });
+    quote! {
+        let mut cv_derive_impl_index = 0;
+        #(#value_recurse)*
+
+        Self {
+            #(#instant_recurse)*
+        }
+    }
+}
+
+pub(crate) fn nb_elements(data: &StructData) -> TokenStream {
+    let value_recurse = data.fields.iter().map(|(_, ty, _)| {
+        quote! {
+            res += <#ty as CircuitVariable>::nb_elements();
+        }
+    });
+
+    quote! {
+        let mut res = 0;
+        #(#value_recurse)*
+
+        res
+    }
+}

--- a/plonky2x-derive/src/lib.rs
+++ b/plonky2x-derive/src/lib.rs
@@ -2,6 +2,7 @@ extern crate proc_macro;
 
 mod assert_is_valid;
 mod constant;
+mod elements;
 mod init;
 mod value;
 mod variables;
@@ -9,6 +10,7 @@ mod witness;
 
 use assert_is_valid::assert_is_valid;
 use constant::constant;
+use elements::{elements, from_elements, nb_elements};
 use init::init_unsafe;
 use proc_macro2::Ident;
 use quote::quote;
@@ -76,6 +78,9 @@ pub fn derive_circuit_variable(input: proc_macro::TokenStream) -> proc_macro::To
     let assert_is_valid_expanded = assert_is_valid(&data);
     let set_exapaned = set(&data);
     let get_exapaned = get(&data);
+    let elements_expanded = elements(&data);
+    let from_elements_expanded = from_elements(&data);
+    let nb_elements_expanded = nb_elements(&data);
 
     let expanded = quote! {
 
@@ -87,13 +92,6 @@ pub fn derive_circuit_variable(input: proc_macro::TokenStream) -> proc_macro::To
 
             fn init_unsafe<L: PlonkParameters<D>, const D: usize>(builder: &mut CircuitBuilder<L, D>) -> Self {
                 #init_unsafe_expanded
-            }
-
-            fn constant<L: PlonkParameters<D>, const D: usize>(
-                builder: &mut CircuitBuilder<L, D>,
-                value: Self::ValueType<L::Field>,
-            ) -> Self {
-                #constant_expanded
             }
 
             fn variables(&self) -> Vec<Variable> {
@@ -108,12 +106,16 @@ pub fn derive_circuit_variable(input: proc_macro::TokenStream) -> proc_macro::To
                 #assert_is_valid_expanded
             }
 
-            fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-                #get_exapaned
+            fn nb_elements() -> usize {
+                #nb_elements_expanded
             }
 
-            fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-                #set_exapaned
+            fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+                #elements_expanded
+            }
+
+            fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+                #from_elements_expanded
             }
         }
     };

--- a/plonky2x-derive/src/lib.rs
+++ b/plonky2x-derive/src/lib.rs
@@ -72,12 +72,12 @@ pub fn derive_circuit_variable(input: proc_macro::TokenStream) -> proc_macro::To
     let (_, value_ty_generics, _) = value_generics.split_for_impl();
 
     let init_unsafe_expanded = init_unsafe(&data);
-    let constant_expanded = constant(&data);
+    let _constant_expanded = constant(&data);
     let variables_expanded = variables(&data);
     let from_variables_unsafe_expanded = from_variables_unsafe(&data);
     let assert_is_valid_expanded = assert_is_valid(&data);
-    let set_expanded = set(&data);
-    let get_expanded = get(&data);
+    let _set_expanded = set(&data);
+    let _get_expanded = get(&data);
     let elements_expanded = elements(&data);
     let from_elements_expanded = from_elements(&data);
     let nb_elements_expanded = nb_elements(&data);

--- a/plonky2x-derive/src/lib.rs
+++ b/plonky2x-derive/src/lib.rs
@@ -76,8 +76,8 @@ pub fn derive_circuit_variable(input: proc_macro::TokenStream) -> proc_macro::To
     let variables_expanded = variables(&data);
     let from_variables_unsafe_expanded = from_variables_unsafe(&data);
     let assert_is_valid_expanded = assert_is_valid(&data);
-    let set_exapaned = set(&data);
-    let get_exapaned = get(&data);
+    let set_expanded = set(&data);
+    let get_expanded = get(&data);
     let elements_expanded = elements(&data);
     let from_elements_expanded = from_elements(&data);
     let nb_elements_expanded = nb_elements(&data);

--- a/plonky2x/src/backend/circuit/input.rs
+++ b/plonky2x/src/backend/circuit/input.rs
@@ -60,7 +60,7 @@ impl<L: PlonkParameters<D>, const D: usize> PublicInput<L, D> {
     pub fn write<V: CircuitVariable>(&mut self, value: V::ValueType<L::Field>) {
         match self {
             PublicInput::Elements(input) => {
-                input.extend(V::elements::<L, D>(value));
+                input.extend(V::elements::<L::Field>(value));
             }
             _ => panic!("field io is not enabled"),
         };

--- a/plonky2x/src/backend/circuit/output.rs
+++ b/plonky2x/src/backend/circuit/output.rs
@@ -67,7 +67,7 @@ impl<L: PlonkParameters<D>, const D: usize> PublicOutput<L, D> {
         match self {
             PublicOutput::Elements(output) => {
                 let elements = output.drain(0..V::nb_elements()).collect_vec();
-                V::from_elements::<L, D>(&elements)
+                V::from_elements::<L::Field>(&elements)
             }
             _ => panic!("field io is not enabled"),
         }

--- a/plonky2x/src/frontend/ecc/ed25519/gadgets/eddsa.rs
+++ b/plonky2x/src/frontend/ecc/ed25519/gadgets/eddsa.rs
@@ -19,9 +19,7 @@ use crate::frontend::hash::sha::sha512::{
 use crate::frontend::num::biguint::BigUintTarget;
 use crate::frontend::num::nonnative::nonnative::{CircuitBuilderNonNative, NonNativeTarget};
 use crate::frontend::num::u32::gadgets::arithmetic_u32::U32Target;
-use crate::prelude::{
-    CircuitBuilder, CircuitVariable, PlonkParameters, Variable, Witness, WitnessWrite,
-};
+use crate::prelude::{CircuitBuilder, CircuitVariable, PlonkParameters, Variable};
 
 const MAX_NUM_SIGS: usize = 256;
 const COMPRESSED_SIG_AND_PK_LEN_BITS: usize = 512;

--- a/plonky2x/src/frontend/eth/beacon/builder.rs
+++ b/plonky2x/src/frontend/eth/beacon/builder.rs
@@ -976,12 +976,14 @@ pub(crate) mod tests {
         let consensus_rpc = env::var("CONSENSUS_RPC_1").unwrap();
         let client = BeaconClient::new(consensus_rpc);
         let latest_block_root = client.get_finalized_block_root().unwrap();
+        let slot = client.get_finalized_slot().unwrap();
+        let slot: u64 = slot.parse().unwrap();
 
         let mut builder = CircuitBuilder::<L, D>::new();
         builder.set_beacon_client(client);
 
         let block_root = builder.constant::<Bytes32Variable>(bytes32!(latest_block_root));
-        let idx = builder.constant::<U64Variable>(7450000);
+        let idx = builder.constant::<U64Variable>(slot - 100);
         let historical_block = builder.beacon_get_historical_block(block_root, idx);
         builder.watch(&historical_block, "historical_block");
 

--- a/plonky2x/src/frontend/eth/beacon/vars/balances.rs
+++ b/plonky2x/src/frontend/eth/beacon/vars/balances.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 use plonky2x_derive::CircuitVariable;
 
 use crate::backend::circuit::PlonkParameters;

--- a/plonky2x/src/frontend/eth/beacon/vars/compressed_validator.rs
+++ b/plonky2x/src/frontend/eth/beacon/vars/compressed_validator.rs
@@ -1,5 +1,4 @@
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 
 use crate::frontend::eth::vars::BLSPubkeyVariable;
 use crate::prelude::{Bytes32Variable, CircuitBuilder, CircuitVariable, PlonkParameters, Variable};

--- a/plonky2x/src/frontend/eth/beacon/vars/header.rs
+++ b/plonky2x/src/frontend/eth/beacon/vars/header.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 use plonky2x_derive::CircuitVariable;
 
 use crate::backend::circuit::PlonkParameters;

--- a/plonky2x/src/frontend/eth/beacon/vars/validator.rs
+++ b/plonky2x/src/frontend/eth/beacon/vars/validator.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::witness::{Witness, WitnessWrite};
+use plonky2x_derive::CircuitVariable;
 
 use crate::backend::circuit::PlonkParameters;
 use crate::frontend::builder::CircuitBuilder;

--- a/plonky2x/src/frontend/eth/beacon/vars/validator.rs
+++ b/plonky2x/src/frontend/eth/beacon/vars/validator.rs
@@ -46,32 +46,67 @@ impl CircuitVariable for BeaconValidatorVariable {
         }
     }
 
-    #[allow(unused_variables)]
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        Self {
-            pubkey: BLSPubkeyVariable::constant(builder, bytes!(value.pubkey)),
-            withdrawal_credentials: Bytes32Variable::constant(
-                builder,
-                bytes32!(value.withdrawal_credentials),
-            ),
-            effective_balance: U256Variable::constant(builder, value.effective_balance.into()),
-            slashed: BoolVariable::constant(builder, value.slashed),
-            activation_eligibility_epoch: U256Variable::constant(
-                builder,
-                value.activation_eligibility_epoch.into(),
-            ),
-            activation_epoch: U256Variable::constant(builder, value.activation_epoch.into()),
-            exit_epoch: U256Variable::constant(
-                builder,
-                value.exit_epoch.parse::<u64>().unwrap().into(),
-            ),
-            withdrawable_epoch: U256Variable::constant(
-                builder,
-                value.withdrawable_epoch.parse::<u64>().unwrap().into(),
-            ),
+    fn nb_elements() -> usize {
+        let pubkey = BLSPubkeyVariable::nb_elements();
+        let withdrawal_credentials = Bytes32Variable::nb_elements();
+        let effective_balance = U256Variable::nb_elements();
+        let slashed = BoolVariable::nb_elements();
+        let activation_eligibility_epoch = U256Variable::nb_elements();
+        let activation_epoch = U256Variable::nb_elements();
+        let exit_epoch = U256Variable::nb_elements();
+        let withdrawable_epoch = U256Variable::nb_elements();
+        pubkey
+            + withdrawal_credentials
+            + effective_balance
+            + slashed
+            + activation_eligibility_epoch
+            + activation_epoch
+            + exit_epoch
+            + withdrawable_epoch
+    }
+
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        let pubkey = BLSPubkeyVariable::elements(bytes!(value.pubkey));
+        let withdrawal_credentials =
+            Bytes32Variable::elements(bytes32!(value.withdrawal_credentials));
+        let effective_balance = U256Variable::elements(value.effective_balance.into());
+        let slashed = BoolVariable::elements(value.slashed);
+        let activation_eligibility_epoch =
+            U256Variable::elements(value.activation_eligibility_epoch.into());
+        let activation_epoch = U256Variable::elements(value.activation_epoch.into());
+        let exit_epoch = U256Variable::elements(value.exit_epoch.parse::<u64>().unwrap().into());
+        let withdrawable_epoch =
+            U256Variable::elements(value.withdrawable_epoch.parse::<u64>().unwrap().into());
+        pubkey
+            .into_iter()
+            .chain(withdrawal_credentials)
+            .chain(effective_balance)
+            .chain(slashed)
+            .chain(activation_eligibility_epoch)
+            .chain(activation_epoch)
+            .chain(exit_epoch)
+            .chain(withdrawable_epoch)
+            .collect()
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        let pubkey = BLSPubkeyVariable::from_elements(&elements[0..384]);
+        let withdrawal_credentials = Bytes32Variable::from_elements(&elements[384..640]);
+        let effective_balance = U256Variable::from_elements(&elements[640..648]);
+        let slashed = BoolVariable::from_elements(&elements[648..649]);
+        let activation_eligibility_epoch = U256Variable::from_elements(&elements[649..657]);
+        let activation_epoch = U256Variable::from_elements(&elements[657..665]);
+        let exit_epoch = U256Variable::from_elements(&elements[665..673]);
+        let withdrawable_epoch = U256Variable::from_elements(&elements[673..681]);
+        BeaconValidator {
+            pubkey: hex!(pubkey),
+            withdrawal_credentials: hex!(withdrawal_credentials),
+            effective_balance: effective_balance.as_u64(),
+            slashed,
+            activation_eligibility_epoch: activation_eligibility_epoch.as_u64(),
+            activation_epoch: activation_epoch.as_u64(),
+            exit_epoch: exit_epoch.as_u64().to_string(),
+            withdrawable_epoch: withdrawable_epoch.as_u64().to_string(),
         }
     }
 
@@ -122,38 +157,6 @@ impl CircuitVariable for BeaconValidatorVariable {
         self.activation_epoch.assert_is_valid(builder);
         self.exit_epoch.assert_is_valid(builder);
         self.withdrawable_epoch.assert_is_valid(builder);
-    }
-
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        BeaconValidator {
-            pubkey: hex!(self.pubkey.get(witness)),
-            withdrawal_credentials: hex!(self.withdrawal_credentials.get(witness)),
-            effective_balance: self.effective_balance.get(witness).as_u64(),
-            slashed: self.slashed.get(witness),
-            activation_eligibility_epoch: self.activation_eligibility_epoch.get(witness).as_u64(),
-            activation_epoch: self.activation_epoch.get(witness).as_u64(),
-            exit_epoch: self.exit_epoch.get(witness).as_u64().to_string(),
-            withdrawable_epoch: self.withdrawable_epoch.get(witness).as_u64().to_string(),
-        }
-    }
-
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.pubkey.set(witness, bytes!(value.pubkey));
-        self.withdrawal_credentials
-            .set(witness, bytes32!(value.withdrawal_credentials));
-        self.effective_balance
-            .set(witness, value.effective_balance.into());
-        self.slashed.set(witness, value.slashed);
-        self.activation_eligibility_epoch
-            .set(witness, value.activation_eligibility_epoch.into());
-        self.activation_epoch
-            .set(witness, value.activation_epoch.into());
-        self.exit_epoch
-            .set(witness, value.exit_epoch.parse::<u64>().unwrap().into());
-        self.withdrawable_epoch.set(
-            witness,
-            value.withdrawable_epoch.parse::<u64>().unwrap().into(),
-        );
     }
 }
 

--- a/plonky2x/src/frontend/eth/beacon/vars/validator.rs
+++ b/plonky2x/src/frontend/eth/beacon/vars/validator.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 
 use crate::backend::circuit::PlonkParameters;
 use crate::frontend::builder::CircuitBuilder;

--- a/plonky2x/src/frontend/eth/beacon/vars/validator.rs
+++ b/plonky2x/src/frontend/eth/beacon/vars/validator.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::witness::{Witness, WitnessWrite};
-use plonky2x_derive::CircuitVariable;
 
 use crate::backend::circuit::PlonkParameters;
 use crate::frontend::builder::CircuitBuilder;

--- a/plonky2x/src/frontend/eth/beacon/vars/validators.rs
+++ b/plonky2x/src/frontend/eth/beacon/vars/validators.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 use plonky2x_derive::CircuitVariable;
 
 use crate::backend::circuit::PlonkParameters;

--- a/plonky2x/src/frontend/eth/beacon/vars/withdrawal.rs
+++ b/plonky2x/src/frontend/eth/beacon/vars/withdrawal.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 use plonky2x_derive::CircuitVariable;
 
 use crate::backend::circuit::PlonkParameters;

--- a/plonky2x/src/frontend/eth/beacon/vars/withdrawals.rs
+++ b/plonky2x/src/frontend/eth/beacon/vars/withdrawals.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 use plonky2x_derive::CircuitVariable;
 
 use crate::backend::circuit::PlonkParameters;

--- a/plonky2x/src/frontend/eth/storage/builder.rs
+++ b/plonky2x/src/frontend/eth/storage/builder.rs
@@ -371,8 +371,6 @@ mod tests {
         // Build your circuit.
         let circuit = builder.build();
 
-        debug!("built circuit");
-
         // Write to the circuit input.
         // These values are taken from Ethereum block https://etherscan.io/block/17880427
         let mut input = circuit.input();
@@ -388,11 +386,8 @@ mod tests {
         // Generate a proof.
         let (proof, mut output) = circuit.prove(&input);
 
-        debug!("proven!");
         // Verify proof.
         circuit.verify(&proof, &input, &output);
-
-        debug!("verified!");
 
         // Read output.
         let circuit_value = output.read::<EthLogVariable>();

--- a/plonky2x/src/frontend/eth/storage/builder.rs
+++ b/plonky2x/src/frontend/eth/storage/builder.rs
@@ -332,7 +332,7 @@ mod tests {
                     "0x8fa46ad6b448faefbfc010736a3d39595ca68eb8bdd4e6b4ab30513bab688068"
                 ),
                 difficulty: U256::from("0x0"),
-                number: U64::from("0x110d56b"),
+                number: U64::from("0x110d56b").as_u64(),
                 gas_limit: U256::from("0x1c9c380"),
                 gas_used: U256::from("0x16041f6"),
                 time: U256::from("0x64d41817"),

--- a/plonky2x/src/frontend/eth/storage/builder.rs
+++ b/plonky2x/src/frontend/eth/storage/builder.rs
@@ -65,7 +65,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         log_index: u64,
     ) -> EthLogVariable {
         let generator = EthLogGenerator::new(self, transaction_hash, block_hash, log_index);
-        let value = generator.value;
+        let value = generator.clone().value;
         self.add_simple_generator(generator);
         value
     }
@@ -366,10 +366,12 @@ mod tests {
         let log_index = 0u64;
 
         let value = builder.eth_get_transaction_log(transaction_hash, block_hash, log_index);
-        builder.write(value);
+        builder.write::<EthLogVariable>(value);
 
         // Build your circuit.
         let circuit = builder.build();
+
+        debug!("built circuit");
 
         // Write to the circuit input.
         // These values are taken from Ethereum block https://etherscan.io/block/17880427
@@ -386,8 +388,11 @@ mod tests {
         // Generate a proof.
         let (proof, mut output) = circuit.prove(&input);
 
+        debug!("proven!");
         // Verify proof.
         circuit.verify(&proof, &input, &output);
+
+        debug!("verified!");
 
         // Read output.
         let circuit_value = output.read::<EthLogVariable>();
@@ -400,7 +405,8 @@ mod tests {
                     bytes32!("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
                     bytes32!("0x00000000000000000000000059b4bb1f5d943cf71a10df63f6b743ee4a4489ee"),
                     bytes32!("0x000000000000000000000000def1c0ded9bec7f1a1670819833240f027b25eff")
-                ],
+                ]
+                .to_vec(),
                 data_hash: bytes32!(
                     "0x5cdda96947975d4afbc971c9aa8bb2cc684e158d10a0d878b3a5b8b0f895262c"
                 )

--- a/plonky2x/src/frontend/eth/storage/generators/block.rs
+++ b/plonky2x/src/frontend/eth/storage/generators/block.rs
@@ -83,7 +83,6 @@ impl<L: PlonkParameters<D>, const D: usize> SimpleGenerator<L::Field, D>
             receipt_hash: result.receipts_root,
             // bloom: H256::from_slice(&result.logs_bloom.expect("No bloom").0),
             difficulty: result.difficulty,
-            // TODO: Convert to U64Variable
             number: result.number.unwrap().as_u64(),
             gas_limit: result.gas_limit,
             gas_used: result.gas_used,

--- a/plonky2x/src/frontend/eth/storage/generators/block.rs
+++ b/plonky2x/src/frontend/eth/storage/generators/block.rs
@@ -84,7 +84,7 @@ impl<L: PlonkParameters<D>, const D: usize> SimpleGenerator<L::Field, D>
             // bloom: H256::from_slice(&result.logs_bloom.expect("No bloom").0),
             difficulty: result.difficulty,
             // TODO: Convert to U64Variable
-            number: result.number.expect("No block number"),
+            number: result.number.unwrap().as_u64(),
             gas_limit: result.gas_limit,
             gas_used: result.gas_used,
             time: result.timestamp,

--- a/plonky2x/src/frontend/eth/storage/generators/storage.rs
+++ b/plonky2x/src/frontend/eth/storage/generators/storage.rs
@@ -340,8 +340,6 @@ impl<L: PlonkParameters<D>, const D: usize> SimpleGenerator<L::Field, D> for Eth
             })
             .expect("No transaction receipt found");
 
-        debug!("got transaction receipt {:?}", result.logs[0]);
-
         let log = &result.logs[self.log_index as usize];
         let value = EthLog {
             address: log.address,
@@ -349,8 +347,6 @@ impl<L: PlonkParameters<D>, const D: usize> SimpleGenerator<L::Field, D> for Eth
             data_hash: ethers::types::H256::from_slice(sha2::Sha256::digest(&log.data).as_ref()),
         };
         self.value.set(buffer, value);
-
-        debug!("setting value");
     }
 
     #[allow(unused_variables)]

--- a/plonky2x/src/frontend/eth/storage/generators/storage.rs
+++ b/plonky2x/src/frontend/eth/storage/generators/storage.rs
@@ -13,6 +13,7 @@ use plonky2::plonk::circuit_data::CommonCircuitData;
 use plonky2::util::serialization::{Buffer, IoResult, Read, Write};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
+use tokio::runtime::Runtime;
 
 use crate::backend::circuit::PlonkParameters;
 use crate::frontend::builder::CircuitBuilder;
@@ -328,21 +329,28 @@ impl<L: PlonkParameters<D>, const D: usize> SimpleGenerator<L::Field, D> for Eth
 
         let provider = get_provider(self.chain_id);
 
-        let result: TransactionReceipt = executor::block_on(async {
-            provider
-                .get_transaction_receipt(transaction_hash)
-                .await
-                .expect("Failed to call get_transaction_receipt")
-        })
-        .expect("No transaction receipt found");
+        let rt = Runtime::new().unwrap();
+
+        let result: TransactionReceipt = rt
+            .block_on(async {
+                provider
+                    .get_transaction_receipt(transaction_hash)
+                    .await
+                    .expect("Failed to call get_transaction_receipt")
+            })
+            .expect("No transaction receipt found");
+
+        debug!("got transaction receipt {:?}", result.logs[0]);
 
         let log = &result.logs[self.log_index as usize];
         let value = EthLog {
             address: log.address,
-            topics: [log.topics[0], log.topics[1], log.topics[2]],
+            topics: [log.topics[0], log.topics[1], log.topics[2]].to_vec(),
             data_hash: ethers::types::H256::from_slice(sha2::Sha256::digest(&log.data).as_ref()),
         };
         self.value.set(buffer, value);
+
+        debug!("setting value");
     }
 
     #[allow(unused_variables)]

--- a/plonky2x/src/frontend/eth/storage/vars/block.rs
+++ b/plonky2x/src/frontend/eth/storage/vars/block.rs
@@ -1,8 +1,7 @@
 use std::fmt::Debug;
 
-use ethers::types::{Address, H256, U256, U64};
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
+use plonky2x_derive::CircuitVariable;
 
 use crate::backend::circuit::PlonkParameters;
 use crate::frontend::builder::CircuitBuilder;
@@ -15,25 +14,11 @@ use crate::prelude::Variable;
 /// Follow the following struct in go-ethereum
 /// https://github.com/ethereum/go-ethereum/blob/b6d4f6b66e99c08f419e6a469259cbde1c8b0582/core/types/block.go#L70
 /// https://github.com/gnosis/hashi/blob/main/packages/evm/contracts/adapters/BlockHashOracleAdapter.sol#L24
-/// Note that this only includes certain fields in the certain block header
-#[derive(Debug, Clone, PartialEq)]
-pub struct EthHeader {
-    pub parent_hash: H256,
-    pub uncle_hash: H256,
-    pub coinbase: Address,
-    pub root: H256,
-    pub tx_hash: H256,
-    pub receipt_hash: H256,
-    // pub bloom: Bytes,
-    pub difficulty: U256,
-    pub number: U64,
-    pub gas_limit: U256,
-    pub gas_used: U256,
-    pub time: U256,
-    // pub extra: Bytes,
-}
 
-#[derive(Debug, Clone, Copy)]
+/// Includes a subset of fields in a block header
+#[derive(Debug, Clone, Copy, CircuitVariable)]
+#[value_name(EthHeader)]
+#[value_derive(PartialEq, Eq)]
 pub struct EthHeaderVariable {
     pub parent_hash: Bytes32Variable,
     pub uncle_hash: Bytes32Variable,
@@ -48,163 +33,4 @@ pub struct EthHeaderVariable {
     pub gas_used: U256Variable,
     pub time: U256Variable,
     // pub extra: Bytes32Variable, // TODO: add back once we have arbitrary bytes variables
-}
-
-impl CircuitVariable for EthHeaderVariable {
-    type ValueType<F: RichField> = EthHeader;
-
-    fn init_unsafe<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-    ) -> Self {
-        Self {
-            parent_hash: Bytes32Variable::init_unsafe(builder),
-            uncle_hash: Bytes32Variable::init_unsafe(builder),
-            coinbase: AddressVariable::init_unsafe(builder),
-            root: Bytes32Variable::init_unsafe(builder),
-            tx_hash: Bytes32Variable::init_unsafe(builder),
-            receipt_hash: Bytes32Variable::init_unsafe(builder),
-            // bloom: Bytes32Variable::init(builder),
-            difficulty: U256Variable::init_unsafe(builder),
-            number: U64Variable::init_unsafe(builder),
-            gas_limit: U256Variable::init_unsafe(builder),
-            gas_used: U256Variable::init_unsafe(builder),
-            time: U256Variable::init_unsafe(builder),
-            // extra: Bytes32Variable::init(builder),
-        }
-    }
-
-    #[allow(unused_variables)]
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        todo!()
-    }
-
-    fn variables(&self) -> Vec<Variable> {
-        let mut vars = Vec::new();
-        vars.extend(self.parent_hash.variables());
-        vars.extend(self.uncle_hash.variables());
-        vars.extend(self.coinbase.variables());
-        vars.extend(self.root.variables());
-        vars.extend(self.tx_hash.variables());
-        vars.extend(self.receipt_hash.variables());
-        // vars.extend(self.bloom.variables());
-        vars.extend(self.difficulty.variables());
-        vars.extend(self.number.variables());
-        vars.extend(self.gas_limit.variables());
-        vars.extend(self.gas_used.variables());
-        vars.extend(self.time.variables());
-        // vars.extend(self.extra.variables());
-        vars
-    }
-
-    #[allow(unused_variables)]
-    fn from_variables_unsafe(variables: &[Variable]) -> Self {
-        let parent_hash = Bytes32Variable::from_variables_unsafe(&variables[0..32 * 8]);
-        let mut offset = 32 * 8;
-        let uncle_hash =
-            Bytes32Variable::from_variables_unsafe(&variables[offset..offset + 32 * 8]);
-        offset += 32 * 8;
-        let coinbase = AddressVariable::from_variables_unsafe(&variables[offset..offset + 8 * 20]);
-        offset += 8 * 20;
-        let root = Bytes32Variable::from_variables_unsafe(&variables[offset..offset + 32 * 8]);
-        offset += 32 * 8;
-
-        let tx_hash = Bytes32Variable::from_variables_unsafe(&variables[offset..offset + 32 * 8]);
-        offset += 32 * 8;
-
-        let receipt_hash =
-            Bytes32Variable::from_variables_unsafe(&variables[offset..offset + 32 * 8]);
-        offset += 32 * 8;
-
-        // let bloom = Bytes32Variable::from_variables(&variables[offset..offset + 32 * 8]);
-        // offset += 32 * 8;
-
-        let difficulty = U256Variable::from_variables_unsafe(&variables[offset..offset + 4]);
-        offset += 4;
-
-        let number = U64Variable::from_variables_unsafe(&variables[offset..offset + 1]);
-        offset += 1;
-
-        let gas_limit = U256Variable::from_variables_unsafe(&variables[offset..offset + 4]);
-        offset += 4;
-
-        let gas_used = U256Variable::from_variables_unsafe(&variables[offset..offset + 4]);
-        offset += 4;
-
-        let time = U256Variable::from_variables_unsafe(&variables[offset..offset + 4]);
-
-        // let extra = Bytes32Variable::from_variables(&variables[offset+8..offset+8+32*8]);
-
-        Self {
-            parent_hash,
-            uncle_hash,
-            coinbase,
-            root,
-            tx_hash,
-            receipt_hash,
-            // bloom,
-            difficulty,
-            number,
-            gas_limit,
-            gas_used,
-            time,
-            // extra
-        }
-    }
-
-    fn assert_is_valid<L: PlonkParameters<D>, const D: usize>(
-        &self,
-        builder: &mut CircuitBuilder<L, D>,
-    ) {
-        self.parent_hash.assert_is_valid(builder);
-        self.uncle_hash.assert_is_valid(builder);
-        self.coinbase.assert_is_valid(builder);
-        self.root.assert_is_valid(builder);
-        self.tx_hash.assert_is_valid(builder);
-        self.receipt_hash.assert_is_valid(builder);
-        // self.bloom.assert_is_valid(builder);
-        self.difficulty.assert_is_valid(builder);
-        self.number.assert_is_valid(builder);
-        self.gas_limit.assert_is_valid(builder);
-        self.gas_used.assert_is_valid(builder);
-        self.time.assert_is_valid(builder);
-    }
-
-    #[allow(unused_variables)]
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        EthHeader {
-            parent_hash: self.parent_hash.get(witness),
-            uncle_hash: self.uncle_hash.get(witness),
-            coinbase: self.coinbase.get(witness),
-            root: self.root.get(witness),
-            tx_hash: self.tx_hash.get(witness),
-            receipt_hash: self.receipt_hash.get(witness),
-            // bloom: self.bloom.get(witness),
-            difficulty: self.difficulty.get(witness),
-            number: U64::from(self.number.get(witness)),
-            gas_limit: self.gas_limit.get(witness),
-            gas_used: self.gas_used.get(witness),
-            time: self.time.get(witness),
-            // extra: self.extra.get(witness).as_bytes().to_vec().into(),
-        }
-    }
-
-    #[allow(unused_variables)]
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.parent_hash.set(witness, value.parent_hash);
-        self.uncle_hash.set(witness, value.uncle_hash);
-        self.coinbase.set(witness, value.coinbase);
-        self.root.set(witness, value.root);
-        self.tx_hash.set(witness, value.tx_hash);
-        self.receipt_hash.set(witness, value.receipt_hash);
-        // self.bloom.set(witness, value.bloom);
-        self.difficulty.set(witness, value.difficulty);
-        self.number.set(witness, value.number.as_u64());
-        self.gas_limit.set(witness, value.gas_limit);
-        self.gas_used.set(witness, value.gas_used);
-        self.time.set(witness, value.time);
-        // self.extra.set(witness, H256::from_slice(value.extra.0.as_ref()));
-    }
 }

--- a/plonky2x/src/frontend/eth/storage/vars/storage.rs
+++ b/plonky2x/src/frontend/eth/storage/vars/storage.rs
@@ -7,7 +7,7 @@ use crate::backend::circuit::PlonkParameters;
 use crate::frontend::builder::CircuitBuilder;
 use crate::frontend::eth::vars::AddressVariable;
 use crate::frontend::vars::{Bytes32Variable, CircuitVariable, U256Variable};
-use crate::prelude::Variable;
+use crate::prelude::{ArrayVariable, Variable};
 
 #[derive(Debug, Clone, Copy, CircuitVariable)]
 #[value_name(EthProof)]
@@ -24,11 +24,11 @@ pub struct EthAccountVariable {
     pub storage_hash: Bytes32Variable,
 }
 
-#[derive(Debug, Clone, Copy, CircuitVariable)]
+#[derive(Debug, Clone, CircuitVariable)]
 #[value_name(EthLog)]
 #[value_derive(PartialEq, Eq)]
 pub struct EthLogVariable {
     pub address: AddressVariable,
-    pub topics: [Bytes32Variable; 3],
+    pub topics: ArrayVariable<Bytes32Variable, 3>,
     pub data_hash: Bytes32Variable,
 }

--- a/plonky2x/src/frontend/eth/storage/vars/storage.rs
+++ b/plonky2x/src/frontend/eth/storage/vars/storage.rs
@@ -1,82 +1,22 @@
 use std::fmt::Debug;
 
-use array_macro::array;
-use ethers::types::{Address, H256, U256};
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
+use plonky2x_derive::CircuitVariable;
 
 use crate::backend::circuit::PlonkParameters;
 use crate::frontend::builder::CircuitBuilder;
 use crate::frontend::eth::vars::AddressVariable;
-use crate::frontend::vars::{Bytes32Variable, CircuitVariable, U256Variable, VariableStream};
+use crate::frontend::vars::{Bytes32Variable, CircuitVariable, U256Variable};
 use crate::prelude::Variable;
 
-#[derive(Debug, Clone, Copy)]
-pub struct EthProof {
-    pub proof: H256,
-}
-
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, CircuitVariable)]
+#[value_name(EthProof)]
 pub struct EthProofVariable {
     pub proof: Bytes32Variable,
 }
 
-impl CircuitVariable for EthProofVariable {
-    type ValueType<F: RichField> = EthProof;
-
-    fn init_unsafe<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-    ) -> Self {
-        Self {
-            proof: Bytes32Variable::init_unsafe(builder),
-        }
-    }
-
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        Self {
-            proof: Bytes32Variable::constant(builder, value.proof),
-        }
-    }
-
-    fn variables(&self) -> Vec<Variable> {
-        self.proof.variables()
-    }
-
-    fn from_variables_unsafe(variables: &[Variable]) -> Self {
-        Self {
-            proof: Bytes32Variable::from_variables_unsafe(variables),
-        }
-    }
-    fn assert_is_valid<L: PlonkParameters<D>, const D: usize>(
-        &self,
-        builder: &mut CircuitBuilder<L, D>,
-    ) {
-        self.proof.assert_is_valid(builder);
-    }
-
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        EthProof {
-            proof: self.proof.get(witness),
-        }
-    }
-
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.proof.set(witness, value.proof);
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct EthAccount {
-    pub balance: U256,
-    pub code_hash: H256,
-    pub nonce: U256,
-    pub storage_hash: H256,
-}
-
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, CircuitVariable)]
+#[value_name(EthAccount)]
 pub struct EthAccountVariable {
     pub balance: U256Variable,
     pub code_hash: Bytes32Variable,
@@ -84,176 +24,11 @@ pub struct EthAccountVariable {
     pub storage_hash: Bytes32Variable,
 }
 
-impl CircuitVariable for EthAccountVariable {
-    type ValueType<F: RichField> = EthAccount;
-
-    fn init_unsafe<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-    ) -> Self {
-        Self {
-            balance: U256Variable::init_unsafe(builder),
-            code_hash: Bytes32Variable::init_unsafe(builder),
-            nonce: U256Variable::init_unsafe(builder),
-            storage_hash: Bytes32Variable::init_unsafe(builder),
-        }
-    }
-
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        Self {
-            balance: U256Variable::constant(builder, value.balance),
-            code_hash: Bytes32Variable::constant(builder, value.code_hash),
-            nonce: U256Variable::constant(builder, value.nonce),
-            storage_hash: Bytes32Variable::constant(builder, value.storage_hash),
-        }
-    }
-
-    fn variables(&self) -> Vec<Variable> {
-        let mut vars = Vec::new();
-        vars.extend(self.balance.variables());
-        vars.extend(self.code_hash.variables());
-        vars.extend(self.nonce.variables());
-        vars.extend(self.storage_hash.variables());
-        vars
-    }
-
-    fn from_variables_unsafe(variables: &[Variable]) -> Self {
-        let balance = U256Variable::from_variables_unsafe(&variables[0..4]);
-        let mut offset = 4;
-        let code_hash = Bytes32Variable::from_variables_unsafe(&variables[offset..offset + 32 * 8]);
-        offset += 32 * 8;
-        let nonce = U256Variable::from_variables_unsafe(&variables[offset..offset + 4]);
-        offset += 4;
-        let storage_hash =
-            Bytes32Variable::from_variables_unsafe(&variables[offset..offset + 32 * 8]);
-        Self {
-            balance,
-            code_hash,
-            nonce,
-            storage_hash,
-        }
-    }
-
-    fn assert_is_valid<L: PlonkParameters<D>, const D: usize>(
-        &self,
-        builder: &mut CircuitBuilder<L, D>,
-    ) {
-        self.balance.assert_is_valid(builder);
-        self.code_hash.assert_is_valid(builder);
-        self.nonce.assert_is_valid(builder);
-        self.storage_hash.assert_is_valid(builder);
-    }
-
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        EthAccount {
-            balance: self.balance.get(witness),
-            code_hash: self.code_hash.get(witness),
-            nonce: self.nonce.get(witness),
-            storage_hash: self.storage_hash.get(witness),
-        }
-    }
-
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.balance.set(witness, value.balance);
-        self.code_hash.set(witness, value.code_hash);
-        self.nonce.set(witness, value.nonce);
-        self.storage_hash.set(witness, value.storage_hash);
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct EthLog {
-    pub address: Address,
-    pub topics: [H256; 3],
-    pub data_hash: H256,
-}
-
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, CircuitVariable)]
+#[value_name(EthLog)]
+#[value_derive(PartialEq, Eq)]
 pub struct EthLogVariable {
     pub address: AddressVariable,
     pub topics: [Bytes32Variable; 3],
     pub data_hash: Bytes32Variable,
-}
-
-impl CircuitVariable for EthLogVariable {
-    type ValueType<F: RichField> = EthLog;
-
-    fn init_unsafe<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-    ) -> Self {
-        Self {
-            address: AddressVariable::init_unsafe(builder),
-            topics: array![_ => Bytes32Variable::init_unsafe(builder); 3],
-            data_hash: Bytes32Variable::init_unsafe(builder),
-        }
-    }
-
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        Self {
-            address: AddressVariable::constant(builder, value.address),
-            topics: array![i => Bytes32Variable::constant(builder, value.topics[i]); 3],
-            data_hash: Bytes32Variable::constant(builder, value.data_hash),
-        }
-    }
-
-    fn variables(&self) -> Vec<Variable> {
-        let mut vars = Vec::new();
-        vars.extend(self.address.variables());
-        vars.extend(
-            self.topics
-                .iter()
-                .flat_map(|t| t.variables())
-                .collect::<Vec<Variable>>(),
-        );
-        vars.extend(self.data_hash.variables());
-        vars
-    }
-
-    fn from_variables_unsafe(variables: &[Variable]) -> Self {
-        let mut var_buffer = VariableStream::from_variables(variables.to_vec());
-        let address = var_buffer.read::<AddressVariable>();
-        let topics = array![_ => var_buffer.read::<Bytes32Variable>(); 3];
-        let data_hash = var_buffer.read::<Bytes32Variable>();
-        Self {
-            address,
-            topics,
-            data_hash,
-        }
-    }
-
-    fn assert_is_valid<L: PlonkParameters<D>, const D: usize>(
-        &self,
-        builder: &mut CircuitBuilder<L, D>,
-    ) {
-        self.address.assert_is_valid(builder);
-        for topic in self.topics.iter() {
-            topic.assert_is_valid(builder);
-        }
-        self.data_hash.assert_is_valid(builder);
-    }
-
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        EthLog {
-            address: self.address.get(witness),
-            topics: [
-                self.topics[0].get(witness),
-                self.topics[1].get(witness),
-                self.topics[2].get(witness),
-            ],
-            data_hash: self.data_hash.get(witness),
-        }
-    }
-
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.address.set(witness, value.address);
-        self.topics[0].set(witness, value.topics[0]);
-        self.topics[1].set(witness, value.topics[1]);
-        self.topics[2].set(witness, value.topics[2]);
-        self.data_hash.set(witness, value.data_hash);
-    }
 }

--- a/plonky2x/src/frontend/eth/vars.rs
+++ b/plonky2x/src/frontend/eth/vars.rs
@@ -23,11 +23,16 @@ impl CircuitVariable for BLSPubkeyVariable {
         Self(BytesVariable::init_unsafe(builder))
     }
 
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        Self(BytesVariable::constant(builder, value))
+    fn nb_elements() -> usize {
+        BytesVariable::<48>::nb_elements()
+    }
+
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        BytesVariable::<48>::elements(value)
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        BytesVariable::<48>::from_elements(elements)
     }
 
     fn variables(&self) -> Vec<Variable> {
@@ -43,14 +48,6 @@ impl CircuitVariable for BLSPubkeyVariable {
         builder: &mut CircuitBuilder<L, D>,
     ) {
         self.0.assert_is_valid(builder);
-    }
-
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        self.0.get(witness)
-    }
-
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.0.set(witness, value)
     }
 }
 
@@ -66,14 +63,16 @@ impl CircuitVariable for AddressVariable {
         Self(BytesVariable::init_unsafe(builder))
     }
 
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        Self(BytesVariable::constant(
-            builder,
-            value.as_bytes().try_into().expect("wrong slice length"),
-        ))
+    fn nb_elements() -> usize {
+        BytesVariable::<20>::nb_elements()
+    }
+
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        BytesVariable::<20>::elements(value.into())
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        H160::from_slice(&BytesVariable::<20>::from_elements(elements))
     }
 
     fn variables(&self) -> Vec<Variable> {
@@ -89,17 +88,6 @@ impl CircuitVariable for AddressVariable {
         builder: &mut CircuitBuilder<L, D>,
     ) {
         self.0.assert_is_valid(builder);
-    }
-
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        H160::from_slice(&self.0.get(witness))
-    }
-
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.0.set(
-            witness,
-            value.as_bytes().try_into().expect("wrong slice length"),
-        )
     }
 }
 

--- a/plonky2x/src/frontend/eth/vars.rs
+++ b/plonky2x/src/frontend/eth/vars.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use ethers::types::H160;
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 
 use crate::backend::circuit::PlonkParameters;
 use crate::frontend::builder::CircuitBuilder;

--- a/plonky2x/src/frontend/hash/poseidon/poseidon256.rs
+++ b/plonky2x/src/frontend/hash/poseidon/poseidon256.rs
@@ -1,7 +1,6 @@
 use array_macro::array;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::target::BoolTarget;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 
 use crate::backend::circuit::PlonkParameters;

--- a/plonky2x/src/frontend/mapreduce/generator.rs
+++ b/plonky2x/src/frontend/mapreduce/generator.rs
@@ -181,7 +181,7 @@ where
         // Write vector of input values.
         dst.write_usize(self.inputs.len())?;
         for i in 0..self.inputs.len() {
-            dst.write_field_vec::<L::Field>(&Input::elements::<L, D>(self.inputs[i].clone()))?;
+            dst.write_field_vec::<L::Field>(&Input::elements::<L::Field>(self.inputs[i].clone()))?;
         }
 
         // Write proof target.
@@ -212,7 +212,7 @@ where
         let inputs_len = src.read_usize()?;
         for _ in 0..inputs_len {
             let input_elements: Vec<L::Field> = src.read_field_vec(Input::nb_elements())?;
-            inputs.push(Input::from_elements::<L, D>(&input_elements));
+            inputs.push(Input::from_elements::<L::Field>(&input_elements));
         }
 
         // Read proof.

--- a/plonky2x/src/frontend/mapreduce/mod.rs
+++ b/plonky2x/src/frontend/mapreduce/mod.rs
@@ -23,7 +23,6 @@ use core::marker::PhantomData;
 use itertools::Itertools;
 use log::debug;
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 use plonky2x_derive::CircuitVariable;
 

--- a/plonky2x/src/frontend/merkle/tree.rs
+++ b/plonky2x/src/frontend/merkle/tree.rs
@@ -1,5 +1,4 @@
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 
 use crate::prelude::*;
 

--- a/plonky2x/src/frontend/num/nonnative/nonnative.rs
+++ b/plonky2x/src/frontend/num/nonnative/nonnative.rs
@@ -9,7 +9,7 @@ use plonky2::field::types::PrimeField;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::generator::{GeneratedValues, SimpleGenerator};
 use plonky2::iop::target::{BoolTarget, Target};
-use plonky2::iop::witness::{PartitionWitness, Witness, WitnessWrite};
+use plonky2::iop::witness::{PartitionWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder as BaseCircuitBuilder;
 use plonky2::plonk::circuit_data::CommonCircuitData;
 use plonky2::util::ceil_div_usize;

--- a/plonky2x/src/frontend/recursion/hash.rs
+++ b/plonky2x/src/frontend/recursion/hash.rs
@@ -43,7 +43,7 @@ impl CircuitVariable for HashOutVariable {
     }
 
     fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
-        value.elements.iter().map(|e| *e).collect()
+        value.elements.to_vec()
     }
 
     fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {

--- a/plonky2x/src/frontend/recursion/hash.rs
+++ b/plonky2x/src/frontend/recursion/hash.rs
@@ -32,19 +32,24 @@ impl CircuitVariable for HashOutVariable {
         }
     }
 
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        Self {
-            elements: value.elements.map(|e| builder.constant(e)),
-        }
-    }
-
     fn assert_is_valid<L: PlonkParameters<D>, const D: usize>(
         &self,
         _builder: &mut CircuitBuilder<L, D>,
     ) {
+    }
+
+    fn nb_elements() -> usize {
+        NUM_HASH_OUT_ELTS
+    }
+
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        value.elements.iter().map(|e| *e).collect()
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        HashOut {
+            elements: elements.try_into().unwrap(),
+        }
     }
 
     fn variables(&self) -> Vec<Variable> {
@@ -54,18 +59,6 @@ impl CircuitVariable for HashOutVariable {
     fn from_variables_unsafe(variables: &[Variable]) -> Self {
         Self {
             elements: variables.try_into().unwrap(),
-        }
-    }
-
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        HashOut {
-            elements: self.elements.map(|v| v.get(witness)),
-        }
-    }
-
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        for (elt, value) in self.elements.iter().zip(value.elements.iter()) {
-            elt.set(witness, *value)
         }
     }
 }

--- a/plonky2x/src/frontend/uint/uint128.rs
+++ b/plonky2x/src/frontend/uint/uint128.rs
@@ -1,7 +1,6 @@
 use array_macro::array;
 use ethers::types::U128;
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 
 use super::Uint;
 use crate::frontend::num::biguint::{BigUintTarget, CircuitBuilderBiguint};

--- a/plonky2x/src/frontend/uint/uint256.rs
+++ b/plonky2x/src/frontend/uint/uint256.rs
@@ -1,7 +1,6 @@
 use array_macro::array;
 use ethers::types::U256;
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 
 use super::Uint;
 use crate::frontend::num::biguint::{BigUintTarget, CircuitBuilderBiguint};

--- a/plonky2x/src/frontend/uint/uint32.rs
+++ b/plonky2x/src/frontend/uint/uint32.rs
@@ -1,10 +1,8 @@
 use std::fmt::Debug;
 
-use curta::math::field::Field;
 use itertools::Itertools;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::target::BoolTarget;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 
 use crate::backend::circuit::PlonkParameters;
 use crate::frontend::builder::CircuitBuilder;

--- a/plonky2x/src/frontend/uint/uint32.rs
+++ b/plonky2x/src/frontend/uint/uint32.rs
@@ -29,16 +29,6 @@ impl CircuitVariable for U32Variable {
         Self(Variable::init_unsafe(builder))
     }
 
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        Self(Variable::constant(
-            builder,
-            L::Field::from_canonical_u32(value),
-        ))
-    }
-
     fn variables(&self) -> Vec<Variable> {
         vec![self.0]
     }
@@ -54,13 +44,17 @@ impl CircuitVariable for U32Variable {
         builder.api.u32_to_bits_le(U32Target(self.targets()[0]));
     }
 
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        let v = witness.get_target(self.0 .0);
-        v.to_canonical_u64() as u32
+    fn nb_elements() -> usize {
+        1
     }
 
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        witness.set_target(self.0 .0, F::from_canonical_u32(value));
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        vec![F::from_canonical_u32(value)]
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        let v = Variable::from_elements(&[elements[0]]);
+        v.to_canonical_u64() as u32
     }
 }
 

--- a/plonky2x/src/frontend/uint/uint32_n.rs
+++ b/plonky2x/src/frontend/uint/uint32_n.rs
@@ -18,16 +18,6 @@ macro_rules! make_uint32_n {
                 }
             }
 
-            fn constant<L: PlonkParameters<D>, const D: usize>(
-                builder: &mut CircuitBuilder<L, D>,
-                value: Self::ValueType<L::Field>,
-            ) -> Self {
-                let limbs = <$b as Uint<$c>>::to_u32_limbs(value);
-                Self {
-                    limbs: array![i => U32Variable::constant(builder, limbs[i]); $c],
-                }
-            }
-
             fn variables(&self) -> Vec<Variable> {
                 self.limbs.iter().map(|x| x.0).collect()
             }
@@ -48,20 +38,22 @@ macro_rules! make_uint32_n {
                 }
             }
 
-            fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-                let mut value_limbs: [u32; $c] = [0; $c];
-                for i in 0..$c {
-                    value_limbs[i] = self.limbs[i].get(witness);
-                }
-
-                <$b as Uint<$c>>::from_u32_limbs(value_limbs)
+            fn nb_elements() -> usize {
+                U32Variable::nb_elements() * $c
             }
 
-            fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: $b) {
+            fn elements<F: RichField>(value: $b) -> Vec<F> {
                 let limbs = <$b as Uint<$c>>::to_u32_limbs(value);
+                limbs.iter().flat_map(|x| U32Variable::elements(*x)).collect()
+            }
+
+            fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+                let mut value_limbs: [u32; $c] = [0; $c];
                 for i in 0..$c {
-                    self.limbs[i].set(witness, limbs[i]);
+                    // There is 1 element in each U32 Variable
+                    value_limbs[i] = U32Variable::from_elements(&elements[i .. i+1]);
                 }
+                <$b as Uint<$c>>::from_u32_limbs(value_limbs)
             }
         }
 

--- a/plonky2x/src/frontend/uint/uint64.rs
+++ b/plonky2x/src/frontend/uint/uint64.rs
@@ -1,7 +1,6 @@
 use array_macro::array;
 use ethers::types::U64;
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 
 use super::uint256::U256Variable;
 use super::Uint;

--- a/plonky2x/src/frontend/vars/array.rs
+++ b/plonky2x/src/frontend/vars/array.rs
@@ -7,7 +7,6 @@ use plonky2::hash::hash_types::RichField;
 use plonky2::hash::poseidon::PoseidonHash;
 use plonky2::iop::challenger::RecursiveChallenger;
 use plonky2::iop::target::Target;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 use serde::{Deserialize, Serialize};
 
 use super::{BoolVariable, ByteVariable, CircuitVariable, ValueStream, Variable, VariableStream};

--- a/plonky2x/src/frontend/vars/boolean.rs
+++ b/plonky2x/src/frontend/vars/boolean.rs
@@ -24,16 +24,6 @@ impl CircuitVariable for BoolVariable {
         Self(Variable::init_unsafe(builder))
     }
 
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        Self(Variable::constant(
-            builder,
-            L::Field::from_canonical_u64(value as u64),
-        ))
-    }
-
     fn variables(&self) -> Vec<Variable> {
         vec![self.0]
     }
@@ -52,12 +42,17 @@ impl CircuitVariable for BoolVariable {
             .assert_bool(BoolTarget::new_unsafe(self.targets()[0]))
     }
 
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        witness.get_target(self.0 .0) == F::from_canonical_u64(1)
+    fn nb_elements() -> usize {
+        1
     }
 
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        witness.set_target(self.0 .0, F::from_canonical_u64(value as u64));
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        vec![F::from_canonical_u64(value as u64)]
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        assert_eq!(elements.len(), 1);
+        elements[0] == F::ONE
     }
 }
 

--- a/plonky2x/src/frontend/vars/boolean.rs
+++ b/plonky2x/src/frontend/vars/boolean.rs
@@ -1,9 +1,7 @@
 use std::fmt::Debug;
 
-use plonky2::field::types::Field;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::target::{BoolTarget, Target};
-use plonky2::iop::witness::{Witness, WitnessWrite};
 use serde::{Deserialize, Serialize};
 
 use super::{CircuitVariable, Variable};

--- a/plonky2x/src/frontend/vars/byte.rs
+++ b/plonky2x/src/frontend/vars/byte.rs
@@ -4,7 +4,6 @@ use array_macro::array;
 use itertools::Itertools;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::target::{BoolTarget, Target};
-use plonky2::iop::witness::{Witness, WitnessWrite};
 use serde::{Deserialize, Serialize};
 
 use super::{BoolVariable, CircuitVariable, EvmVariable, Variable};

--- a/plonky2x/src/frontend/vars/bytes.rs
+++ b/plonky2x/src/frontend/vars/bytes.rs
@@ -3,7 +3,6 @@ use std::ops::{Index, Range};
 
 use array_macro::array;
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 
 use super::{CircuitVariable, EvmVariable, Variable};
 use crate::backend::circuit::PlonkParameters;

--- a/plonky2x/src/frontend/vars/bytes32.rs
+++ b/plonky2x/src/frontend/vars/bytes32.rs
@@ -1,9 +1,7 @@
-use core::str::Bytes;
 use std::fmt::Debug;
 
 use ethers::types::H256;
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 
 use super::{
     ByteVariable, BytesVariable, CircuitVariable, EvmVariable, SSZVariable, U256Variable, Variable,

--- a/plonky2x/src/frontend/vars/bytes32.rs
+++ b/plonky2x/src/frontend/vars/bytes32.rs
@@ -1,3 +1,4 @@
+use core::str::Bytes;
 use std::fmt::Debug;
 
 use ethers::types::H256;
@@ -49,16 +50,6 @@ impl CircuitVariable for Bytes32Variable {
         Self(BytesVariable::init_unsafe(builder))
     }
 
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        Self(BytesVariable::constant(
-            builder,
-            value.as_bytes().try_into().unwrap(),
-        ))
-    }
-
     fn variables(&self) -> Vec<super::Variable> {
         self.0.variables()
     }
@@ -74,13 +65,16 @@ impl CircuitVariable for Bytes32Variable {
         self.0.assert_is_valid(builder)
     }
 
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        let bytes = self.0.get(witness);
-        H256::from_slice(&bytes)
+    fn nb_elements() -> usize {
+        BytesVariable::<32>::nb_elements()
     }
 
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.0.set(witness, value.0);
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        BytesVariable::<32>::elements(value.as_bytes().try_into().unwrap())
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        H256::from_slice(&BytesVariable::<32>::from_elements(elements))
     }
 }
 

--- a/plonky2x/src/frontend/vars/collections.rs
+++ b/plonky2x/src/frontend/vars/collections.rs
@@ -1,6 +1,5 @@
 use array_macro::array;
 use plonky2::hash::hash_types::RichField;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 
 use super::{CircuitVariable, Variable};
 use crate::backend::circuit::PlonkParameters;
@@ -44,7 +43,7 @@ impl<const N: usize, V: CircuitVariable> CircuitVariable for [V; N] {
 
     fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
         assert!(value.len() == N);
-        value.iter().flat_map(|v| V::elements(*v)).collect()
+        value.into_iter().flat_map(|v| V::elements(v)).collect()
     }
 
     fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {

--- a/plonky2x/src/frontend/vars/collections.rs
+++ b/plonky2x/src/frontend/vars/collections.rs
@@ -15,13 +15,6 @@ impl<const N: usize, V: CircuitVariable> CircuitVariable for [V; N] {
         array![V::init_unsafe(_builder); N]
     }
 
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        value.map(|v| builder.constant(v))
-    }
-
     fn variables(&self) -> Vec<Variable> {
         self.iter().flat_map(|v| v.variables()).collect()
     }
@@ -45,15 +38,23 @@ impl<const N: usize, V: CircuitVariable> CircuitVariable for [V; N] {
         }
     }
 
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        self.clone().map(|v| v.get(witness))
+    fn nb_elements() -> usize {
+        V::nb_elements() * N
     }
 
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        assert_eq!(self.len(), value.len());
-        for (v, value) in self.iter().zip(value) {
-            v.set(witness, value);
-        }
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        assert!(value.len() == N);
+        value.iter().flat_map(|v| V::elements(*v)).collect()
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        assert_eq!(elements.len(), N * V::nb_elements());
+        elements
+            .chunks_exact(V::nb_elements())
+            .map(V::from_elements)
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -64,16 +65,6 @@ impl<V1: CircuitVariable, V2: CircuitVariable> CircuitVariable for (V1, V2) {
         builder: &mut CircuitBuilder<L, D>,
     ) -> Self {
         (V1::init_unsafe(builder), V2::init_unsafe(builder))
-    }
-
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        (
-            V1::constant(builder, value.0),
-            V2::constant(builder, value.1),
-        )
     }
 
     fn variables(&self) -> Vec<Variable> {
@@ -97,13 +88,23 @@ impl<V1: CircuitVariable, V2: CircuitVariable> CircuitVariable for (V1, V2) {
         self.1.assert_is_valid(builder);
     }
 
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        (self.0.get(witness), self.1.get(witness))
+    fn nb_elements() -> usize {
+        V1::nb_elements() + V2::nb_elements()
     }
 
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.0.set(witness, value.0);
-        self.1.set(witness, value.1);
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        V1::elements(value.0)
+            .into_iter()
+            .chain(V2::elements(value.1))
+            .collect()
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        assert_eq!(elements.len(), V1::nb_elements() + V2::nb_elements());
+        (
+            V1::from_elements(&elements[..V1::nb_elements()]),
+            V2::from_elements(&elements[V1::nb_elements()..]),
+        )
     }
 }
 
@@ -119,17 +120,6 @@ impl<V1: CircuitVariable, V2: CircuitVariable, V3: CircuitVariable> CircuitVaria
             V1::init_unsafe(builder),
             V2::init_unsafe(builder),
             V3::init_unsafe(builder),
-        )
-    }
-
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        (
-            V1::constant(builder, value.0),
-            V2::constant(builder, value.1),
-            V3::constant(builder, value.2),
         )
     }
 
@@ -166,18 +156,29 @@ impl<V1: CircuitVariable, V2: CircuitVariable, V3: CircuitVariable> CircuitVaria
         self.2.assert_is_valid(builder);
     }
 
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        (
-            self.0.get(witness),
-            self.1.get(witness),
-            self.2.get(witness),
-        )
+    fn nb_elements() -> usize {
+        V1::nb_elements() + V2::nb_elements() + V3::nb_elements()
     }
 
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.0.set(witness, value.0);
-        self.1.set(witness, value.1);
-        self.2.set(witness, value.2);
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        [
+            &V1::elements(value.0)[..],
+            &V2::elements(value.1)[..],
+            &V3::elements(value.2)[..],
+        ]
+        .concat()
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        assert_eq!(
+            elements.len(),
+            V1::nb_elements() + V2::nb_elements() + V3::nb_elements()
+        );
+        (
+            V1::from_elements(&elements[..V1::nb_elements()]),
+            V2::from_elements(&elements[V1::nb_elements()..]),
+            V3::from_elements(&elements[V1::nb_elements() + V2::nb_elements()..]),
+        )
     }
 }
 
@@ -199,18 +200,6 @@ impl<V1: CircuitVariable, V2: CircuitVariable, V3: CircuitVariable, V4: CircuitV
             V2::init_unsafe(builder),
             V3::init_unsafe(builder),
             V4::init_unsafe(builder),
-        )
-    }
-
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        (
-            V1::constant(builder, value.0),
-            V2::constant(builder, value.1),
-            V3::constant(builder, value.2),
-            V4::constant(builder, value.3),
         )
     }
 
@@ -255,20 +244,33 @@ impl<V1: CircuitVariable, V2: CircuitVariable, V3: CircuitVariable, V4: CircuitV
         self.3.assert_is_valid(builder);
     }
 
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        (
-            self.0.get(witness),
-            self.1.get(witness),
-            self.2.get(witness),
-            self.3.get(witness),
-        )
+    fn nb_elements() -> usize {
+        V1::nb_elements() + V2::nb_elements() + V3::nb_elements() + V4::nb_elements()
     }
 
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.0.set(witness, value.0);
-        self.1.set(witness, value.1);
-        self.2.set(witness, value.2);
-        self.3.set(witness, value.3);
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        [
+            &V1::elements(value.0)[..],
+            &V2::elements(value.1)[..],
+            &V3::elements(value.2)[..],
+            &V4::elements(value.3)[..],
+        ]
+        .concat()
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        assert_eq!(
+            elements.len(),
+            V1::nb_elements() + V2::nb_elements() + V3::nb_elements() + V4::nb_elements()
+        );
+        (
+            V1::from_elements(&elements[..V1::nb_elements()]),
+            V2::from_elements(&elements[V1::nb_elements()..]),
+            V3::from_elements(&elements[V1::nb_elements() + V2::nb_elements()..]),
+            V4::from_elements(
+                &elements[V1::nb_elements() + V2::nb_elements() + V3::nb_elements()..],
+            ),
+        )
     }
 }
 
@@ -297,19 +299,6 @@ impl<
             V3::init_unsafe(builder),
             V4::init_unsafe(builder),
             V5::init_unsafe(builder),
-        )
-    }
-
-    fn constant<L: PlonkParameters<D>, const D: usize>(
-        builder: &mut CircuitBuilder<L, D>,
-        value: Self::ValueType<L::Field>,
-    ) -> Self {
-        (
-            V1::constant(builder, value.0),
-            V2::constant(builder, value.1),
-            V3::constant(builder, value.2),
-            V4::constant(builder, value.3),
-            V5::constant(builder, value.4),
         )
     }
 
@@ -364,21 +353,47 @@ impl<
         self.4.assert_is_valid(builder);
     }
 
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        (
-            self.0.get(witness),
-            self.1.get(witness),
-            self.2.get(witness),
-            self.3.get(witness),
-            self.4.get(witness),
-        )
+    fn nb_elements() -> usize {
+        V1::nb_elements()
+            + V2::nb_elements()
+            + V3::nb_elements()
+            + V4::nb_elements()
+            + V5::nb_elements()
     }
 
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        self.0.set(witness, value.0);
-        self.1.set(witness, value.1);
-        self.2.set(witness, value.2);
-        self.3.set(witness, value.3);
-        self.4.set(witness, value.4);
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        [
+            &V1::elements(value.0)[..],
+            &V2::elements(value.1)[..],
+            &V3::elements(value.2)[..],
+            &V4::elements(value.3)[..],
+            &V5::elements(value.4)[..],
+        ]
+        .concat()
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        assert_eq!(
+            elements.len(),
+            V1::nb_elements()
+                + V2::nb_elements()
+                + V3::nb_elements()
+                + V4::nb_elements()
+                + V5::nb_elements()
+        );
+        (
+            V1::from_elements(&elements[..V1::nb_elements()]),
+            V2::from_elements(&elements[V1::nb_elements()..]),
+            V3::from_elements(&elements[V1::nb_elements() + V2::nb_elements()..]),
+            V4::from_elements(
+                &elements[V1::nb_elements() + V2::nb_elements() + V3::nb_elements()..],
+            ),
+            V5::from_elements(
+                &elements[V1::nb_elements()
+                    + V2::nb_elements()
+                    + V3::nb_elements()
+                    + V4::nb_elements()..],
+            ),
+        )
     }
 }

--- a/plonky2x/src/frontend/vars/mod.rs
+++ b/plonky2x/src/frontend/vars/mod.rs
@@ -16,13 +16,13 @@ pub use bytes32::*;
 use itertools::Itertools;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::target::Target;
-use plonky2::iop::witness::{PartialWitness, Witness, WitnessWrite};
+use plonky2::iop::witness::{Witness, WitnessWrite};
 pub use stream::*;
 pub use variable::*;
 
 pub use super::uint::uint256::*;
 pub use super::uint::uint32::*;
-use crate::backend::circuit::{generate_witness, DefaultParameters, PlonkParameters};
+use crate::backend::circuit::{DefaultParameters, PlonkParameters};
 use crate::frontend::builder::CircuitBuilder;
 use crate::utils;
 

--- a/plonky2x/src/frontend/vars/stream.rs
+++ b/plonky2x/src/frontend/vars/stream.rs
@@ -146,7 +146,7 @@ impl<L: PlonkParameters<D>, const D: usize> ValueStream<L, D> {
 
     pub fn read_value<V: CircuitVariable>(&mut self) -> V::ValueType<L::Field> {
         let elements = self.0.read_exact(V::nb_elements());
-        V::from_elements::<L, D>(elements)
+        V::from_elements::<L::Field>(elements)
     }
 
     pub fn read_exact(&mut self, len: usize) -> &[L::Field] {
@@ -162,7 +162,7 @@ impl<L: PlonkParameters<D>, const D: usize> ValueStream<L, D> {
     }
 
     pub fn write_value<V: CircuitVariable>(&mut self, value: V::ValueType<L::Field>) {
-        self.0.write_slice(&V::elements::<L, D>(value));
+        self.0.write_slice(&V::elements::<L::Field>(value));
     }
 }
 

--- a/plonky2x/src/frontend/vars/variable.rs
+++ b/plonky2x/src/frontend/vars/variable.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::target::Target;
-use plonky2::iop::witness::{Witness, WitnessWrite};
 use serde::{Deserialize, Serialize};
 
 use super::CircuitVariable;

--- a/plonky2x/src/frontend/vars/variable.rs
+++ b/plonky2x/src/frontend/vars/variable.rs
@@ -50,12 +50,17 @@ impl CircuitVariable for Variable {
     ) {
     }
 
-    fn get<F: RichField, W: Witness<F>>(&self, witness: &W) -> Self::ValueType<F> {
-        witness.get_target(self.0)
+    fn nb_elements() -> usize {
+        1
     }
 
-    fn set<F: RichField, W: WitnessWrite<F>>(&self, witness: &mut W, value: Self::ValueType<F>) {
-        witness.set_target(self.0, value);
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        vec![value]
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        assert_eq!(elements.len(), 1);
+        elements[0]
     }
 }
 

--- a/plonky2x/src/utils/poseidon/mod.rs
+++ b/plonky2x/src/utils/poseidon/mod.rs
@@ -26,7 +26,7 @@ where
     for i in 0..inputs.len() / B {
         let mut input = Vec::new();
         for j in 0..B {
-            input.extend(Input::elements::<L, D>(inputs[i * B + j].clone()));
+            input.extend(Input::elements::<L::Field>(inputs[i * B + j].clone()));
         }
         let h = hash_n_to_hash_no_pad::<
             L::Field,
@@ -62,5 +62,5 @@ where
         leafs = tmp;
     }
 
-    PoseidonHashOutVariable::from_elements::<L, D>(&leafs[0])
+    PoseidonHashOutVariable::from_elements::<L::Field>(&leafs[0])
 }


### PR DESCRIPTION
## Overview
- Refactor `CircuitVariable` to remove previously slow `elements`, `from_elements` and `nb_elements` functions. 
- `CircuitVariable` implements `get`, `set` and `constant` in the trait. 
- Implementers of `CircuitVariable` will need to define `nb_elements`, `from_elements` and `elements`, or derive them from existing `CircuitVariable` implmentations.