### PR TITLE
feat: option to disable fees for Gateway

### DIFF
--- a/contracts/src/SuccinctGateway.sol
+++ b/contracts/src/SuccinctGateway.sol
@@ -247,6 +247,13 @@ contract SuccinctGateway is ISuccinctGateway, FunctionRegistry, TimelockedUpgrad
         emit Call(_functionId, inputHash, outputHash);
     }
 
+    /// @dev Sets the fee vault to a new address. Can be set to address(0) to disable fees.
+    /// @param _feeVault The address of the fee vault.
+    function setFeeVault(address _feeVault) external onlyGuardian {
+        emit SetFeeVault(feeVault, _feeVault);
+        feeVault = _feeVault;
+    }
+
     /// @dev Computes a unique identifier for a request.
     /// @param _functionId The function identifier.
     /// @param _inputHash The hash of the function input.

--- a/contracts/src/interfaces/ISuccinctGateway.sol
+++ b/contracts/src/interfaces/ISuccinctGateway.sol
@@ -25,6 +25,7 @@ interface ISuccinctGatewayEvents {
         uint32 indexed nonce, bytes32 indexed functionId, bytes32 inputHash, bytes32 outputHash
     );
     event Call(bytes32 indexed functionId, bytes32 inputHash, bytes32 outputHash);
+    event SetFeeVault(address indexed oldFeeVault, address indexed newFeeVault);
 }
 
 interface ISuccinctGatewayErrors {

--- a/contracts/test/SuccinctGateway.t.sol
+++ b/contracts/test/SuccinctGateway.t.sol
@@ -69,6 +69,7 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
         address callbackAddress = consumer;
         bytes4 callbackSelector = TestConsumer.handleCallback.selector;
         uint32 callbackGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
+        uint256 fee = DEFAULT_FEE;
         bytes memory context = abi.encode(nonce);
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
@@ -83,10 +84,10 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
             callbackAddress,
             callbackSelector,
             callbackGasLimit,
-            DEFAULT_FEE
+            fee
         );
         vm.prank(sender);
-        TestConsumer(consumer).requestCallback{value: DEFAULT_FEE}(INPUT);
+        TestConsumer(consumer).requestCallback{value: fee}(INPUT);
 
         assertEq(prevNonce + 1, SuccinctGateway(gateway).nonce());
         assertEq(TestConsumer(consumer).handledRequests(0), false);
@@ -116,6 +117,7 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
         address callbackAddress = consumer;
         bytes4 callbackSelector = TestConsumer.handleCallback.selector;
         uint32 callbackGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
+        uint256 fee = 0;
         bytes memory context = abi.encode(nonce);
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
@@ -130,10 +132,10 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
             callbackAddress,
             callbackSelector,
             callbackGasLimit,
-            0
+            fee
         );
         vm.prank(sender);
-        TestConsumer(consumer).requestCallback{value: 0}(INPUT);
+        TestConsumer(consumer).requestCallback{value: fee}(INPUT);
 
         assertEq(nonce + 1, SuccinctGateway(gateway).nonce());
         assertEq(TestConsumer(consumer).handledRequests(0), false);
@@ -169,6 +171,7 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
         address callbackAddress = consumer;
         bytes4 callbackSelector = TestConsumer.handleCallback.selector;
         uint32 callbackGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
+        uint256 fee = DEFAULT_FEE;
         bytes memory context = abi.encode(nonce);
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
@@ -183,10 +186,10 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
             callbackAddress,
             callbackSelector,
             callbackGasLimit,
-            DEFAULT_FEE
+            fee
         );
         vm.prank(sender);
-        TestConsumer(consumer).requestCallback{value: DEFAULT_FEE}(INPUT);
+        TestConsumer(consumer).requestCallback{value: fee}(INPUT);
 
         assertEq(prevNonce + 1, SuccinctGateway(gateway).nonce());
         assertEq(TestConsumer(consumer).handledRequests(0), false);
@@ -217,13 +220,12 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
         address callAddress = consumer;
         bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector, OUTPUT, 0);
         uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
+        uint256 fee = DEFAULT_FEE;
 
         // Request
         vm.expectEmit(true, true, true, true, gateway);
-        emit RequestCall(
-            functionId, input, callAddress, callData, callGasLimit, consumer, DEFAULT_FEE
-        );
-        TestConsumer(consumer).requestCall{value: DEFAULT_FEE}(input, callData);
+        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
+        TestConsumer(consumer).requestCall{value: fee}(input, callData);
 
         assertEq(TestConsumer(consumer).handledRequests(0), false);
 
@@ -245,11 +247,12 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
         address callAddress = consumer;
         bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector, OUTPUT, 0);
         uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
+        uint256 fee = 0;
 
         // Request
         vm.expectEmit(true, true, true, true, gateway);
-        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, 0);
-        TestConsumer(consumer).requestCall{value: 0}(input, callData);
+        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
+        TestConsumer(consumer).requestCall{value: fee}(input, callData);
 
         assertEq(TestConsumer(consumer).handledRequests(0), false);
 
@@ -274,13 +277,12 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
         address callAddress = consumer;
         bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector, OUTPUT, 0);
         uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
+        uint256 fee = DEFAULT_FEE;
 
         // Request
         vm.expectEmit(true, true, true, true, gateway);
-        emit RequestCall(
-            functionId, input, callAddress, callData, callGasLimit, consumer, DEFAULT_FEE
-        );
-        TestConsumer(consumer).requestCall{value: DEFAULT_FEE}(input, callData);
+        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
+        TestConsumer(consumer).requestCall{value: fee}(input, callData);
 
         assertEq(TestConsumer(consumer).handledRequests(0), false);
 
@@ -308,6 +310,46 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
 
         // Verifiy call
         TestConsumer(consumer).verifiedCall(input);
+    }
+
+    function test_RevertVerifiedCall_WhenNotSet() public {
+        bytes memory input = INPUT;
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+
+        // Verifiy call
+        vm.expectRevert(abi.encodeWithSelector(InvalidCall.selector, functionId, input));
+        TestConsumer(consumer).verifiedCall(input);
+    }
+
+    function test_SetFeeVault() public {
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+        bytes memory input = INPUT;
+        address callAddress = consumer;
+        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector, OUTPUT, 0);
+        uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
+        uint256 fee = DEFAULT_FEE;
+        address newFeeVault = address(new SuccinctFeeVault(guardian));
+
+        // Set FeeVault
+        vm.expectEmit(true, true, true, true, gateway);
+        emit SetFeeVault(SuccinctGateway(gateway).feeVault(), newFeeVault);
+        vm.prank(guardian);
+        SuccinctGateway(gateway).setFeeVault(newFeeVault);
+
+        assertEq(SuccinctGateway(gateway).feeVault(), newFeeVault);
+
+        // Request with fee
+        vm.expectEmit(true, true, true, true, gateway);
+        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
+        TestConsumer(consumer).requestCall{value: fee}(input, callData);
+    }
+
+    function test_RevertSetFeeVault_WhenNotGuardian() public {
+        address newFeeVault = address(new SuccinctFeeVault(guardian));
+
+        // Set FeeVault
+        vm.expectRevert();
+        SuccinctGateway(gateway).setFeeVault(newFeeVault);
     }
 
     function test_RevertCallback() public {

--- a/contracts/test/SuccinctGateway.t.sol
+++ b/contracts/test/SuccinctGateway.t.sol
@@ -212,6 +212,32 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
         assertEq(TestConsumer(consumer).handledRequests(0), true);
     }
 
+    function test_RevertCallback() public {
+        uint32 nonce = SuccinctGateway(gateway).nonce();
+        bytes32 inputHash = INPUT_HASH;
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+        address callbackAddress = consumer;
+        bytes4 callbackSelector = TestConsumer.handleCallback.selector;
+        uint32 callbackGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
+        bytes memory context = abi.encode(nonce);
+        bytes memory output = OUTPUT;
+        bytes memory proof = PROOF;
+
+        // Fulfill
+        vm.expectRevert();
+        SuccinctGateway(gateway).fulfillCallback(
+            nonce,
+            functionId,
+            inputHash,
+            callbackAddress,
+            callbackSelector,
+            callbackGasLimit,
+            context,
+            output,
+            proof
+        );
+    }
+
     function test_Call() public {
         bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
         bytes memory input = INPUT;
@@ -296,6 +322,21 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
         assertEq(TestConsumer(consumer).handledRequests(0), true);
     }
 
+    function test_RevertCall() public {
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+        bytes memory input = INPUT;
+        bytes memory output = OUTPUT;
+        bytes memory proof = PROOF;
+        address callAddress = consumer;
+        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector, OUTPUT, 0);
+
+        // Fulfill
+        vm.expectRevert();
+        SuccinctGateway(gateway).fulfillCall(
+            functionId, input, output, proof, callAddress, callData
+        );
+    }
+
     function test_VerifiedCall() public {
         bytes memory input = INPUT;
         bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
@@ -350,55 +391,5 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
         // Set FeeVault
         vm.expectRevert();
         SuccinctGateway(gateway).setFeeVault(newFeeVault);
-    }
-
-    function test_RevertCallback() public {
-        uint32 nonce = SuccinctGateway(gateway).nonce();
-        bytes32 inputHash = INPUT_HASH;
-        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
-        address callbackAddress = consumer;
-        bytes4 callbackSelector = TestConsumer.handleCallback.selector;
-        uint32 callbackGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
-        bytes memory context = abi.encode(nonce);
-        bytes memory output = OUTPUT;
-        bytes memory proof = PROOF;
-
-        // Fulfill
-        vm.expectRevert();
-        SuccinctGateway(gateway).fulfillCallback(
-            nonce,
-            functionId,
-            inputHash,
-            callbackAddress,
-            callbackSelector,
-            callbackGasLimit,
-            context,
-            output,
-            proof
-        );
-    }
-
-    function test_RevertCall() public {
-        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
-        bytes memory input = INPUT;
-        bytes memory output = OUTPUT;
-        bytes memory proof = PROOF;
-        address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector, OUTPUT, 0);
-
-        // Fulfill
-        vm.expectRevert();
-        SuccinctGateway(gateway).fulfillCall(
-            functionId, input, output, proof, callAddress, callData
-        );
-    }
-
-    function test_RevertVerifiedCall() public {
-        bytes memory input = INPUT;
-        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
-
-        // Verifiy call
-        vm.expectRevert(abi.encodeWithSelector(InvalidCall.selector, functionId, input));
-        TestConsumer(consumer).verifiedCall(input);
     }
 }


### PR DESCRIPTION
Guardian can now update FeeVault address, and this acts as a way to disable fees since it can now be set to `address(0)`.