### PR TITLE
test: coverage for SuccinctFeeVault

### DIFF
--- a/contracts/src/payments/SuccinctFeeVault.sol
+++ b/contracts/src/payments/SuccinctFeeVault.sol
@@ -25,17 +25,6 @@ contract SuccinctFeeVault is IFeeVault, TimelockedUpgradeable {
     /// @notice The allowed senders for the deduct functions.
     mapping(address => bool) public allowedDeductors;
 
-    event Received(address indexed account, address indexed token, uint256 amount);
-    event Deducted(address indexed account, address indexed token, uint256 amount);
-    event Collected(address indexed to, address indexed token, uint256 amount);
-
-    error InvalidAccount(address account);
-    error InvalidToken(address token);
-    error InsufficentAllowance(address token, uint256 amount);
-    error InsufficientBalance(address token, uint256 amount);
-    error FailedToSendNative(uint256 amount);
-    error OnlyDeductor(address sender);
-
     modifier onlyDeductor() {
         if (!allowedDeductors[msg.sender]) {
             revert OnlyDeductor(msg.sender);
@@ -168,4 +157,8 @@ contract SuccinctFeeVault is IFeeVault, TimelockedUpgradeable {
 
         emit Collected(_to, _token, _amount);
     }
+
+    /// @dev This empty reserved space to add new variables without shifting down storage.
+    ///      See: https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+    uint256[50] private __gap;
 }

--- a/contracts/src/payments/SuccinctFeeVault.sol
+++ b/contracts/src/payments/SuccinctFeeVault.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.16;
 import {IFeeVault} from "./interfaces/IFeeVault.sol";
 import {TimelockedUpgradeable} from "../upgrades/TimelockedUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title SuccinctFeeVault
 /// @author Succinct Labs
@@ -18,6 +19,8 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 ///         make a bulk deposit.
 /// @dev Address(0) is used to represent native currency in places where token address is specified.
 contract SuccinctFeeVault is IFeeVault, TimelockedUpgradeable {
+    using SafeERC20 for IERC20;
+
     /// @notice Tracks the amount of active balance that an account has for Succinct services.
     /// @dev balances[token][account] returns the amount of balance for token the account has. To
     ///      check native currency balance, use address(0) as the token address.
@@ -83,7 +86,7 @@ contract SuccinctFeeVault is IFeeVault, TimelockedUpgradeable {
             revert InsufficentAllowance(_token, _amount);
         }
 
-        token.transferFrom(msg.sender, address(this), _amount);
+        token.safeTransferFrom(msg.sender, address(this), _amount);
         balances[_token][_account] += _amount;
 
         emit Received(_account, _token, _amount);

--- a/contracts/src/payments/interfaces/IFeeVault.sol
+++ b/contracts/src/payments/interfaces/IFeeVault.sol
@@ -1,22 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
-interface IFeeVault {
-    /// @notice Returns the amount of active balance that an account has.
-    /// @param token The address of the token to check the balance of. To check native currency
-    ///        balance, use address(0) as the token address.
-    /// @param account The address of the account to check the balance of.
+interface IFeeVaultEvents {
+    event Received(address indexed account, address indexed token, uint256 amount);
+    event Deducted(address indexed account, address indexed token, uint256 amount);
+    event Collected(address indexed to, address indexed token, uint256 amount);
+}
+
+interface IFeeVaultErrors {
+    error InvalidAccount(address account);
+    error InvalidToken(address token);
+    error InsufficentAllowance(address token, uint256 amount);
+    error InsufficientBalance(address token, uint256 amount);
+    error FailedToSendNative(uint256 amount);
+    error OnlyDeductor(address sender);
+}
+
+interface IFeeVault is IFeeVaultEvents, IFeeVaultErrors {
     function balances(address token, address account) external view returns (uint256);
-
-    /// @notice Deposit the specified amount of native currency from the caller.
-    /// @dev The native currency is represented by address(0) in balances.
-    /// @param account The account to deposit the native currency for.
     function depositNative(address account) external payable;
-
-    /// @notice Deposit the specified amount of the specified token from the caller.
-    /// @dev MUST approve this contract to spend at least `amount` of `token` before calling this.
-    /// @param account The account to deposit the tokens to.
-    /// @param token The address of the token to deposit.
-    /// @param amount The amount of the token to deposit.
     function deposit(address account, address token, uint256 amount) external;
 }

--- a/contracts/test/payments/SuccinctFeeVault.t.sol
+++ b/contracts/test/payments/SuccinctFeeVault.t.sol
@@ -1,0 +1,647 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.16;
+
+import "forge-std/Vm.sol";
+import "forge-std/console.sol";
+import "forge-std/Test.sol";
+
+import {IFeeVault, IFeeVaultEvents, IFeeVaultErrors} from "src/payments/interfaces/IFeeVault.sol";
+import {SuccinctFeeVault} from "src/payments/SuccinctFeeVault.sol";
+import {Proxy} from "src/upgrades/Proxy.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {AccessControlUpgradeable} from
+    "@openzeppelin-upgradeable/contracts/access/AccessControlUpgradeable.sol";
+
+contract SuccinctFeeVaultTest is Test, IFeeVaultEvents, IFeeVaultErrors {
+    uint256 constant FEE = 1 ether;
+
+    address internal timelock;
+    address internal guardian;
+    address internal feeVault;
+    address internal token1;
+    address internal token2;
+    address internal deductor;
+    address internal collector;
+    address internal spender1;
+    address internal spender2;
+    address internal account1;
+    address internal account2;
+
+    function setUp() public {
+        // Init variables
+        timelock = makeAddr("timelock");
+        guardian = makeAddr("guardian");
+
+        token1 = address(new ERC20("UnicornToken", "UNI"));
+        token2 = address(new ERC20("DragonToken", "DRG"));
+        deductor = makeAddr("deductor");
+        collector = makeAddr("collector");
+        spender1 = makeAddr("spender1");
+        spender2 = makeAddr("spender2");
+        account1 = makeAddr("account1");
+        account2 = makeAddr("account2");
+
+        // Deploy FeeVault
+        address feeVaultImpl = address(new SuccinctFeeVault());
+        feeVault = address(new Proxy(feeVaultImpl, ""));
+        SuccinctFeeVault(feeVault).initialize(timelock, guardian);
+
+        // Add deductor
+        vm.prank(guardian);
+        SuccinctFeeVault(feeVault).addDeductor(deductor);
+
+        // Give spenders some native
+        vm.deal(spender1, FEE);
+        vm.deal(spender2, FEE);
+
+        // Give spenders some tokens
+        deal(token1, spender1, FEE);
+        deal(token2, spender1, FEE);
+        deal(token1, spender2, FEE);
+        deal(token2, spender2, FEE);
+    }
+}
+
+contract SetUpTest is SuccinctFeeVaultTest {
+    function test_SetUp() public {
+        assertTrue(AccessControlUpgradeable(feeVault).hasRole(keccak256("TIMELOCK_ROLE"), timelock));
+        assertTrue(AccessControlUpgradeable(feeVault).hasRole(keccak256("GUARDIAN_ROLE"), guardian));
+        assertEq(SuccinctFeeVault(feeVault).allowedDeductors(deductor), true);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token2, spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token2, spender2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token2, account1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token2, account2), 0);
+        assertEq(spender1.balance, FEE);
+        assertEq(spender2.balance, FEE);
+        assertEq(ERC20(token1).balanceOf(spender1), FEE);
+        assertEq(ERC20(token2).balanceOf(spender1), FEE);
+        assertEq(ERC20(token1).balanceOf(spender2), FEE);
+        assertEq(ERC20(token2).balanceOf(spender2), FEE);
+    }
+}
+
+contract DeductorTest is SuccinctFeeVaultTest {
+    function test_AddDeductor() public {
+        vm.prank(guardian);
+        SuccinctFeeVault(feeVault).addDeductor(spender1);
+        assertEq(SuccinctFeeVault(feeVault).allowedDeductors(spender1), true);
+    }
+
+    function test_RevertAddDeductor_WhenNotGuardian() public {
+        vm.expectRevert(abi.encodeWithSignature("OnlyGuardian(address)", spender1));
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).addDeductor(spender1);
+        assertEq(SuccinctFeeVault(feeVault).allowedDeductors(spender1), false);
+    }
+
+    function test_RemoveDeductor() public {
+        vm.prank(guardian);
+        SuccinctFeeVault(feeVault).removeDeductor(deductor);
+        assertEq(SuccinctFeeVault(feeVault).allowedDeductors(deductor), false);
+    }
+
+    function test_RevertRemoveDeductor_WhenNotGuardian() public {
+        vm.expectRevert(abi.encodeWithSignature("OnlyGuardian(address)", spender1));
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).removeDeductor(deductor);
+        assertEq(SuccinctFeeVault(feeVault).allowedDeductors(deductor), true);
+    }
+}
+
+contract DepositNativeTest is SuccinctFeeVaultTest {
+    function test_DepositNative() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(account1);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account1), FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account2), 0);
+        assertEq(spender1.balance, 0);
+        assertEq(spender2.balance, FEE);
+        assertEq(address(feeVault).balance, FEE);
+    }
+
+    function test_DepositNative_WhenSameAccount() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(spender1, address(0), FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(spender1);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender1), FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account2), 0);
+        assertEq(spender1.balance, 0);
+        assertEq(spender2.balance, FEE);
+        assertEq(address(feeVault).balance, FEE);
+    }
+
+    function test_DepositNative_WhenSameAccountMultipleSpenders() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(account1);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account1), FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account2), 0);
+        assertEq(spender1.balance, 0);
+        assertEq(spender2.balance, FEE);
+        assertEq(address(feeVault).balance, FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE);
+        vm.prank(spender2);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(account1);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account1), FEE * 2);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account2), 0);
+        assertEq(spender1.balance, 0);
+        assertEq(spender2.balance, 0);
+        assertEq(address(feeVault).balance, FEE * 2);
+    }
+
+    function test_DepositNative_WhenMultipleAccountSameSpender() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE / 2);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE / 2}(account1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account2, address(0), FEE / 2);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE / 2}(account2);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account1), FEE / 2);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account2), FEE / 2);
+        assertEq(spender1.balance, 0);
+        assertEq(spender2.balance, FEE);
+        assertEq(address(feeVault).balance, FEE);
+    }
+
+    function test_DepositNative_WhenZeroAmount() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), 0);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: 0}(account1);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account2), 0);
+        assertEq(spender1.balance, FEE);
+        assertEq(spender2.balance, FEE);
+        assertEq(address(feeVault).balance, 0);
+    }
+
+    function test_RevertDepositNative_WhenZeroAccount() public {
+        vm.expectRevert(abi.encodeWithSelector(InvalidAccount.selector, address(0)));
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(address(0));
+    }
+}
+
+contract DepositTest is SuccinctFeeVaultTest {
+    function test_Deposit() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account1), FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account2), 0);
+        assertEq(ERC20(token1).balanceOf(spender1), 0);
+        assertEq(ERC20(token1).balanceOf(spender2), FEE);
+        assertEq(ERC20(token1).balanceOf(address(feeVault)), FEE);
+    }
+
+    function test_Deposit_WhenSameAccount() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+        vm.expectEmit(true, true, true, true);
+        emit Received(spender1, token1, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(spender1, token1, FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender1), FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender2), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account2), 0);
+        assertEq(ERC20(token1).balanceOf(spender1), 0);
+        assertEq(ERC20(token1).balanceOf(spender2), FEE);
+        assertEq(ERC20(token1).balanceOf(address(feeVault)), FEE);
+    }
+
+    function test_Deposit_WhenSameAccountMultipleTokens() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+        vm.prank(spender1);
+        ERC20(token2).approve(address(feeVault), FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token2, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token2, FEE);
+
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token2, spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account1), FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(token2, account1), FEE);
+        assertEq(ERC20(token1).balanceOf(spender1), 0);
+        assertEq(ERC20(token2).balanceOf(spender1), 0);
+        assertEq(ERC20(token1).balanceOf(spender2), FEE);
+        assertEq(ERC20(token2).balanceOf(spender2), FEE);
+        assertEq(ERC20(token1).balanceOf(address(feeVault)), FEE);
+        assertEq(ERC20(token2).balanceOf(address(feeVault)), FEE);
+    }
+
+    function test_Deposit_WhenMultipleAccountsSameToken() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, FEE / 2);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE / 2);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account2, token1, FEE / 2);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account2, token1, FEE / 2);
+
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account1), FEE / 2);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account2), FEE / 2);
+        assertEq(ERC20(token1).balanceOf(spender1), 0);
+        assertEq(ERC20(token1).balanceOf(spender2), FEE);
+        assertEq(ERC20(token1).balanceOf(address(feeVault)), FEE);
+    }
+
+    function test_Deposit_WhenZeroAmount() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, 0);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, 0);
+
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account1), 0);
+        assertEq(ERC20(token1).balanceOf(spender1), FEE);
+        assertEq(ERC20(token1).balanceOf(spender2), FEE);
+        assertEq(ERC20(token1).balanceOf(address(feeVault)), 0);
+    }
+
+    function test_RevertDeposit_WhenZeroAccount() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+
+        vm.expectRevert(abi.encodeWithSelector(InvalidAccount.selector, address(0)));
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(address(0), token1, FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender1), 0);
+    }
+
+    function test_RevertDeposit_WhenNotApproved() public {
+        vm.expectRevert(abi.encodeWithSelector(InsufficentAllowance.selector, token1, FEE));
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender1), 0);
+    }
+}
+
+contract DeductNativeTest is SuccinctFeeVaultTest {
+    function test_DeductNative() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(account1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Deducted(account1, address(0), FEE);
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deductNative(account1, FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account1), 0);
+    }
+
+    function test_DeductNative_WhenNotFullAmount() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(account1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Deducted(account1, address(0), FEE / 2);
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deductNative(account1, FEE / 2);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account1), FEE / 2);
+    }
+
+    function test_DeductNative_WhenSameAccount() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(spender1, address(0), FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(spender1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Deducted(spender1, address(0), FEE);
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deductNative(spender1, FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), spender1), 0);
+    }
+
+    function test_DeductNative_WhenSameAccountMultipleSpenders() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(account1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE);
+        vm.prank(spender2);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(account1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Deducted(account1, address(0), FEE * 2);
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deductNative(account1, FEE * 2);
+        assertEq(SuccinctFeeVault(feeVault).balances(address(0), account1), 0);
+    }
+
+    function test_DeductNative_WhenNotDeductor() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(account1);
+
+        vm.expectRevert(abi.encodeWithSelector(OnlyDeductor.selector, spender1));
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deductNative(account1, FEE);
+    }
+
+    function test_RevertDeductNative_WhenNotEnoughBalance() public {
+        vm.expectRevert(abi.encodeWithSelector(InsufficientBalance.selector, address(0), FEE));
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deductNative(account1, FEE);
+    }
+}
+
+contract DeductTest is SuccinctFeeVaultTest {
+    function test_Deduct() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Deducted(account1, token1, FEE);
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deduct(account1, token1, FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account1), 0);
+    }
+
+    function test_Deduct_WhenNotFullAmount() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Deducted(account1, token1, FEE / 2);
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deduct(account1, token1, FEE / 2);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account1), FEE / 2);
+    }
+
+    function test_Deduct_WhenSameAccount() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+        vm.expectEmit(true, true, true, true);
+        emit Received(spender1, token1, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(spender1, token1, FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Deducted(spender1, token1, FEE);
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deduct(spender1, token1, FEE);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, spender1), 0);
+    }
+
+    function test_Deduct_WhenSameAccountMultipleTokens() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+        vm.prank(spender1);
+        ERC20(token2).approve(address(feeVault), FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token2, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token2, FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Deducted(account1, token1, FEE);
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deduct(account1, token1, FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Deducted(account1, token2, FEE);
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deduct(account1, token2, FEE);
+
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token2, account1), 0);
+    }
+
+    function test_Deduct_WhenMultipleAccountsSameToken() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, FEE / 2);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE / 2);
+
+        vm.expectEmit(true, true, true, true);
+        emit Received(account2, token1, FEE / 2);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account2, token1, FEE / 2);
+
+        vm.expectEmit(true, true, true, true);
+        emit Deducted(account1, token1, FEE / 2);
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deduct(account1, token1, FEE / 2);
+
+        vm.expectEmit(true, true, true, true);
+        emit Deducted(account2, token1, FEE / 2);
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deduct(account2, token1, FEE / 2);
+
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account1), 0);
+        assertEq(SuccinctFeeVault(feeVault).balances(token1, account2), 0);
+    }
+
+    function test_RevertDeduct_WhenNotDeductor() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE);
+
+        vm.expectRevert(abi.encodeWithSelector(OnlyDeductor.selector, spender1));
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deduct(account1, token1, FEE);
+    }
+
+    function test_RevertDeduct_WhenNotEnoughBalance() public {
+        vm.expectRevert(abi.encodeWithSelector(InsufficientBalance.selector, token1, FEE));
+        vm.prank(deductor);
+        SuccinctFeeVault(feeVault).deduct(account1, token1, FEE);
+    }
+}
+
+contract CollectNativeTest is SuccinctFeeVaultTest {
+    function test_CollectNative() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(account1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Collected(collector, address(0), FEE);
+        vm.prank(guardian);
+        SuccinctFeeVault(feeVault).collectNative(collector, FEE);
+        assertEq(address(feeVault).balance, 0);
+        assertEq(collector.balance, FEE);
+    }
+
+    function test_CollectNative_WhenNotFullAmount() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(account1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Collected(collector, address(0), FEE / 2);
+        vm.prank(guardian);
+        SuccinctFeeVault(feeVault).collectNative(collector, FEE / 2);
+        assertEq(address(feeVault).balance, FEE / 2);
+        assertEq(collector.balance, FEE / 2);
+    }
+
+    function test_CollectNative_WhenZeroAmount() public {
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, address(0), FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).depositNative{value: FEE}(account1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Collected(collector, address(0), 0);
+        vm.prank(guardian);
+        SuccinctFeeVault(feeVault).collectNative(collector, 0);
+        assertEq(address(feeVault).balance, FEE);
+        assertEq(collector.balance, 0);
+    }
+
+    function test_RevertCollectNative_WhenNotOwner() public {
+        vm.expectRevert(abi.encodeWithSignature("OnlyGuardian(address)", spender1));
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).collectNative(collector, FEE);
+    }
+
+    function test_RevertCollectNative_WhenNotEnoughBalance() public {
+        vm.expectRevert(abi.encodeWithSelector(InsufficientBalance.selector, address(0), FEE));
+        vm.prank(guardian);
+        SuccinctFeeVault(feeVault).collectNative(collector, FEE);
+    }
+}
+
+contract CollectTest is SuccinctFeeVaultTest {
+    function test_Collect() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Collected(collector, token1, FEE);
+        vm.prank(guardian);
+        SuccinctFeeVault(feeVault).collect(collector, token1, FEE);
+        assertEq(ERC20(token1).balanceOf(address(feeVault)), 0);
+        assertEq(ERC20(token1).balanceOf(collector), FEE);
+    }
+
+    function test_Collect_WhenNotFullAmount() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Collected(collector, token1, FEE / 2);
+        vm.prank(guardian);
+        SuccinctFeeVault(feeVault).collect(collector, token1, FEE / 2);
+        assertEq(ERC20(token1).balanceOf(address(feeVault)), FEE / 2);
+        assertEq(ERC20(token1).balanceOf(collector), FEE / 2);
+    }
+
+    function test_Collect_WhenZeroAmount() public {
+        vm.prank(spender1);
+        ERC20(token1).approve(address(feeVault), FEE);
+        vm.expectEmit(true, true, true, true);
+        emit Received(account1, token1, FEE);
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).deposit(account1, token1, FEE);
+
+        vm.expectEmit(true, true, true, true);
+        emit Collected(collector, token1, 0);
+        vm.prank(guardian);
+        SuccinctFeeVault(feeVault).collect(collector, token1, 0);
+        assertEq(ERC20(token1).balanceOf(address(feeVault)), FEE);
+        assertEq(ERC20(token1).balanceOf(collector), 0);
+    }
+
+    function test_RevertCollect_WhenNotGuardian() public {
+        vm.expectRevert(abi.encodeWithSignature("OnlyGuardian(address)", spender1));
+        vm.prank(spender1);
+        SuccinctFeeVault(feeVault).collect(collector, token1, FEE);
+    }
+
+    function test_RevertCollect_WhenNotEnoughBalance() public {
+        vm.expectRevert(abi.encodeWithSelector(InsufficientBalance.selector, token1, FEE));
+        vm.prank(guardian);
+        SuccinctFeeVault(feeVault).collect(collector, token1, FEE);
+    }
+}


### PR DESCRIPTION
Output:
```sh
Running 5 tests for test/payments/SuccinctFeeVault.t.sol:CollectNativeTest
[PASS] test_CollectNative() (gas: 98280)
[PASS] test_CollectNative_WhenNotFullAmount() (gas: 98523)
[PASS] test_CollectNative_WhenZeroAmount() (gas: 66557)
[PASS] test_RevertCollectNative_WhenNotEnoughBalance() (gas: 21160)
[PASS] test_RevertCollectNative_WhenNotOwner() (gas: 21030)
Test result: ok. 5 passed; 0 failed; 0 skipped; finished in 4.50ms

Running 6 tests for test/payments/SuccinctFeeVault.t.sol:DeductNativeTest
[PASS] test_DeductNative() (gas: 46735)
[PASS] test_DeductNative_WhenNotDeductor() (gas: 56006)
[PASS] test_DeductNative_WhenNotFullAmount() (gas: 63804)
[PASS] test_DeductNative_WhenSameAccount() (gas: 45149)
[PASS] test_DeductNative_WhenSameAccountMultipleSpenders() (gas: 59139)
[PASS] test_RevertDeductNative_WhenNotEnoughBalance() (gas: 23175)
Test result: ok. 6 passed; 0 failed; 0 skipped; finished in 2.01ms

Running 7 tests for test/payments/SuccinctFeeVault.t.sol:DeductTest
[PASS] test_Deduct() (gas: 94204)
[PASS] test_Deduct_WhenMultipleAccountsSameToken() (gas: 133118)
[PASS] test_Deduct_WhenNotFullAmount() (gas: 98404)
[PASS] test_Deduct_WhenSameAccount() (gas: 92568)
[PASS] test_Deduct_WhenSameAccountMultipleTokens() (gas: 176787)
[PASS] test_RevertDeduct_WhenNotDeductor() (gas: 90179)
[PASS] test_RevertDeduct_WhenNotEnoughBalance() (gas: 25793)
Test result: ok. 7 passed; 0 failed; 0 skipped; finished in 15.62ms

Running 5 tests for test/payments/SuccinctFeeVault.t.sol:CollectTest
[PASS] test_Collect() (gas: 116698)
[PASS] test_Collect_WhenNotFullAmount() (gas: 126633)
[PASS] test_Collect_WhenZeroAmount() (gas: 106474)
[PASS] test_RevertCollect_WhenNotEnoughBalance() (gas: 29075)
[PASS] test_RevertCollect_WhenNotOwner() (gas: 23459)
Test result: ok. 5 passed; 0 failed; 0 skipped; finished in 17.70ms

Running 6 tests for test/payments/SuccinctFeeVault.t.sol:DepositNativeTest
[PASS] test_DepositNative() (gas: 71857)
[PASS] test_DepositNative_WhenMultipleAccountSameSpender() (gas: 105338)
[PASS] test_DepositNative_WhenSameAccount() (gas: 71834)
[PASS] test_DepositNative_WhenSameAccountMultipleSpenders() (gas: 93726)
[PASS] test_DepositNative_WhenZeroAmount() (gas: 45258)
[PASS] test_RevertDepositNative_WhenZeroAccount() (gas: 23144)
Test result: ok. 6 passed; 0 failed; 0 skipped; finished in 4.18ms

Running 7 tests for test/payments/SuccinctFeeVault.t.sol:DepositTest
[PASS] test_Deposit() (gas: 108394)
[PASS] test_Deposit_WhenMultipleAccountsSameToken() (gas: 139259)
[PASS] test_Deposit_WhenSameAccount() (gas: 108394)
[PASS] test_Deposit_WhenSameAccountMultipleTokens() (gas: 178895)
[PASS] test_Deposit_WhenZeroAmount() (gas: 80447)
[PASS] test_RevertDeposit_WhenNotApproved() (gas: 35593)
[PASS] test_RevertDeposit_WhenZeroAccount() (gas: 55745)
Test result: ok. 7 passed; 0 failed; 0 skipped; finished in 5.74ms

Running 1 test for test/payments/SuccinctFeeVault.t.sol:SetUpTest
[PASS] test_SetUp() (gas: 109743)
Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.33ms

Running 4 tests for test/payments/SuccinctFeeVault.t.sol:DeductorTest
[PASS] test_AddDeductor() (gas: 43751)
[PASS] test_RemoveDeductor() (gas: 21897)
[PASS] test_RevertAddDeductor_WhenNotGuardian() (gas: 27183)
[PASS] test_RevertRemoveDeductor_WhenNotGuardian() (gas: 29193)
Test result: ok. 4 passed; 0 failed; 0 skipped; finished in 1.89ms
 
Ran 8 test suites: 41 tests passed, 0 failed, 0 skipped (41 total tests)
```