### PR TITLE
fix(plonky2x): `sha512_pad`

### DIFF
--- a/plonky2x/core/src/frontend/curta/ec/point.rs
+++ b/plonky2x/core/src/frontend/curta/ec/point.rs
@@ -1,7 +1,7 @@
 use curta::chip::ec::point::{AffinePoint, AffinePointRegister};
 use curta::chip::ec::EllipticCurve;
 use curta::chip::register::Register;
-use curve25519_dalek::edwards::CompressedEdwardsY;
+pub use curve25519_dalek::edwards::CompressedEdwardsY;
 
 use crate::frontend::curta::field::variable::FieldVariable;
 use crate::prelude::*;


### PR DESCRIPTION
Extend the input to `pad_sha512` to size `max_num_chunks` * 128.