### PR TITLE
refactor(plonky2x): `get_root_from_hashed_leaves`

### DIFF
--- a/plonky2x/core/src/frontend/merkle/mod.rs
+++ b/plonky2x/core/src/frontend/merkle/mod.rs
@@ -1,2 +1,3 @@
 pub mod tendermint;
 pub mod tree;
+pub mod utils;

--- a/plonky2x/core/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/core/src/frontend/merkle/tendermint.rs
@@ -1,5 +1,6 @@
 use ethers::types::H256;
 use itertools::Itertools;
+use num::pow;
 
 use super::tree::MerkleInclusionProofVariable;
 use crate::backend::circuit::PlonkParameters;
@@ -135,7 +136,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         let empty_bytes = Bytes32Variable::constant(self, H256::from_slice(&[0u8; 32]));
 
         // Extend leaf_hashes and leaves_enabled to be a power of 2.
-        let padded_nb_leaves = log2_ceil_usize(NB_LEAVES);
+        let padded_nb_leaves = pow(2, log2_ceil_usize(NB_LEAVES));
         assert!(padded_nb_leaves >= NB_LEAVES && padded_nb_leaves.is_power_of_two());
 
         // Hash each of the validators to get their corresponding leaf hash.

--- a/plonky2x/core/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/core/src/frontend/merkle/tendermint.rs
@@ -1,7 +1,9 @@
+use ethers::types::H256;
 use itertools::Itertools;
 
 use super::tree::MerkleInclusionProofVariable;
 use crate::backend::circuit::PlonkParameters;
+use crate::frontend::merkle::utils::log2_ceil_usize;
 use crate::frontend::vars::Bytes32Variable;
 use crate::prelude::{
     ArrayVariable, BoolVariable, ByteVariable, BytesVariable, CircuitBuilder, CircuitVariable,
@@ -127,17 +129,26 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         leaf_hashes: Vec<Bytes32Variable>,
         leaves_enabled: Vec<BoolVariable>,
     ) -> Bytes32Variable {
-        assert!(NB_LEAVES.is_power_of_two());
         assert!(leaf_hashes.len() == NB_LEAVES);
         assert!(leaves_enabled.len() == NB_LEAVES);
 
+        let empty_bytes = Bytes32Variable::constant(self, H256::from_slice(&[0u8; 32]));
+
+        // Extend leaf_hashes and leaves_enabled to be a power of 2.
+        let padded_nb_leaves = log2_ceil_usize(NB_LEAVES);
+        assert!(padded_nb_leaves >= NB_LEAVES && padded_nb_leaves.is_power_of_two());
+
         // Hash each of the validators to get their corresponding leaf hash.
+        // Pad the leaves to be a power of 2.
         let mut current_nodes = leaf_hashes.clone();
+        current_nodes.resize(padded_nb_leaves, empty_bytes);
 
         // Whether to treat the validator as empty.
+        // Pad the enabled array to be a power of 2.
         let mut current_node_enabled = leaves_enabled.clone();
+        current_node_enabled.resize(padded_nb_leaves, self._false());
 
-        let mut merkle_layer_size = NB_LEAVES;
+        let mut merkle_layer_size = padded_nb_leaves;
 
         // Hash each layer of nodes to get the root according to the Tendermint spec, starting from the leaves.
         while merkle_layer_size > 1 {

--- a/plonky2x/core/src/frontend/merkle/utils.rs
+++ b/plonky2x/core/src/frontend/merkle/utils.rs
@@ -1,0 +1,15 @@
+pub fn log2_ceil_usize(x: usize) -> usize {
+    if x <= 1 {
+        return 0; // log2(0) and log2(1) are both 0
+    }
+
+    let mut result = 0;
+    let mut value = x - 1; // Subtract 1 to ensure rounding up for powers of 2
+
+    while value > 0 {
+        value >>= 1; // Right shift by 1, equivalent to dividing by 2
+        result += 1;
+    }
+
+    result as usize
+}

--- a/plonky2x/core/src/frontend/merkle/utils.rs
+++ b/plonky2x/core/src/frontend/merkle/utils.rs
@@ -1,13 +1,16 @@
+/// Computes the ceiling of the base 2 log of a `usize`.
 pub fn log2_ceil_usize(x: usize) -> usize {
     if x <= 1 {
-        return 0; // log2(0) and log2(1) are both 0
+        // log2(0) and log2(1) are both 0.
+        return 0;
     }
 
     let mut result = 0;
-    let mut value = x - 1; // Subtract 1 to ensure rounding up for powers of 2
+    // Subtract 1 to ensure rounding up for powers of 2.
+    let mut value = x - 1;
 
     while value > 0 {
-        value >>= 1; // Right shift by 1, equivalent to dividing by 2
+        value >>= 1;
         result += 1;
     }
 

--- a/plonky2x/core/src/utils/lido/mod.rs
+++ b/plonky2x/core/src/utils/lido/mod.rs
@@ -167,6 +167,7 @@ mod tests {
     use super::*;
     use crate::utils;
     #[tokio::test]
+    #[cfg_attr(feature = "ci", ignore)]
     async fn test_lido_metadata() {
         utils::setup_logger();
         let rpc_url = "https://eth.llamarpc.com";


### PR DESCRIPTION
Previously, `get_root_from_hashed_leaves` required an input that had a length that was a power of 2. Now, it pads to the nearest power of 2 greater than the input length.