### PR TITLE
feat: Create a `verify_decoded_mpt_node` for a circuit

### DIFF
--- a/plonky2x/core/src/frontend/eth/mpt/builder.rs
+++ b/plonky2x/core/src/frontend/eth/mpt/builder.rs
@@ -135,7 +135,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
                 self.assert_is_equal(checked_equality, t);
             }
 
-            let mpt_node = self.decode_element_as_list::<ENCODING_LEN, LIST_LEN, ELEMENT_LEN>(
+            let mpt_node = self.decode_mpt_node::<ENCODING_LEN, LIST_LEN, ELEMENT_LEN>(
                 current_node,
                 len_nodes[i],
                 finished,

--- a/plonky2x/core/src/frontend/eth/mpt/builder.rs
+++ b/plonky2x/core/src/frontend/eth/mpt/builder.rs
@@ -78,7 +78,6 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         value: Bytes32Variable,
     ) {
         const ELEMENT_LEN: usize = 32; // Maximum size of list element
-        const LIST_LEN: usize = 17; // Maximum length of the list for each proof element
 
         let tree_radix = self.constant::<Variable>(L::Field::from_canonical_u8(16u8));
         let branch_node_length = self.constant::<Variable>(L::Field::from_canonical_u8(17u8));
@@ -135,7 +134,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
                 self.assert_is_equal(checked_equality, t);
             }
 
-            let mpt_node = self.decode_mpt_node::<ENCODING_LEN, LIST_LEN, ELEMENT_LEN>(
+            let mpt_node = self.decode_mpt_node::<ENCODING_LEN, ELEMENT_LEN>(
                 current_node,
                 len_nodes[i],
                 finished,

--- a/plonky2x/core/src/frontend/vars/mod.rs
+++ b/plonky2x/core/src/frontend/vars/mod.rs
@@ -4,6 +4,7 @@ mod byte;
 mod bytes;
 mod bytes32;
 mod collections;
+mod mpt;
 
 mod stream;
 mod variable;

--- a/plonky2x/core/src/frontend/vars/mod.rs
+++ b/plonky2x/core/src/frontend/vars/mod.rs
@@ -16,6 +16,7 @@ pub use byte::*;
 pub use bytes::*;
 pub use bytes32::*;
 use itertools::Itertools;
+pub use mpt::*;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::target::Target;
 use plonky2::iop::witness::{Witness, WitnessWrite};

--- a/plonky2x/core/src/frontend/vars/mpt.rs
+++ b/plonky2x/core/src/frontend/vars/mpt.rs
@@ -12,7 +12,14 @@ use crate::frontend::builder::CircuitBuilder;
 use crate::frontend::eth::rlp::utils::{MPTNodeFixedSize, MAX_MPT_NODE_SIZE, MAX_RLP_ITEM_SIZE};
 use crate::frontend::ops::{BitAnd, BitOr, BitXor, Not};
 
-/// A variable in the circuit representing a boolean value.
+/// A variable in the circuit representing an MPT node.
+///
+/// The MPT node is represented as a tuple of `(data, lens, len)`, where:
+/// - `data` is an array of bytes representing the data of the node.
+/// - `lens` is an array of `Variable`s representing the true length of each element in `data`.
+/// - `len` is a `Variable` representing the true length of `data`.
+///
+/// The vast majority of time, a node is a branch node.
 #[derive(Debug, Clone)]
 #[allow(clippy::manual_non_exhaustive)]
 pub struct MPTVariable {

--- a/plonky2x/core/src/frontend/vars/mpt.rs
+++ b/plonky2x/core/src/frontend/vars/mpt.rs
@@ -1,0 +1,141 @@
+use std::fmt::Debug;
+
+use curta::chip::register::element;
+use itertools::Itertools;
+use plonky2::hash::hash_types::RichField;
+use plonky2::iop::target::BoolTarget;
+use serde::{Deserialize, Serialize};
+
+use super::{ArrayVariable, ByteVariable, CircuitVariable, Variable};
+use crate::backend::circuit::PlonkParameters;
+use crate::frontend::builder::CircuitBuilder;
+use crate::frontend::eth::rlp::utils::{MPTNodeFixedSize, MAX_MPT_NODE_SIZE, MAX_RLP_ITEM_SIZE};
+use crate::frontend::ops::{BitAnd, BitOr, BitXor, Not};
+
+/// A variable in the circuit representing a boolean value.
+#[derive(Debug, Clone)]
+#[allow(clippy::manual_non_exhaustive)]
+pub struct MPTVariable {
+    pub data: ArrayVariable<ArrayVariable<ByteVariable, MAX_RLP_ITEM_SIZE>, MAX_MPT_NODE_SIZE>,
+    pub lens: ArrayVariable<Variable, MAX_MPT_NODE_SIZE>,
+    pub len: Variable,
+
+    /// This private field is here to force all instantiations to go the methods below.
+    _private: (),
+}
+
+impl CircuitVariable for MPTVariable {
+    type ValueType<F: RichField> = MPTNodeFixedSize;
+
+    fn nb_elements() -> usize {
+        MAX_MPT_NODE_SIZE * MAX_RLP_ITEM_SIZE + MAX_MPT_NODE_SIZE + 1
+    }
+
+    fn from_elements<F: RichField>(elements: &[F]) -> Self::ValueType<F> {
+        todo!()
+    }
+    fn targets(&self) -> Vec<plonky2::iop::target::Target> {
+        self.variables().into_iter().map(|v| v.0).collect()
+    }
+
+    fn from_targets(targets: &[plonky2::iop::target::Target]) -> Self {
+        Self::from_variables_unsafe(&targets.iter().map(|t| Variable(*t)).collect_vec())
+    }
+
+    fn init_unsafe<L: PlonkParameters<D>, const D: usize>(
+        builder: &mut CircuitBuilder<L, D>,
+    ) -> Self {
+        Self {
+            data: ArrayVariable::init_unsafe(builder),
+            lens: ArrayVariable::init_unsafe(builder),
+            len: Variable::init_unsafe(builder),
+            _private: (),
+        }
+    }
+
+    fn variables(&self) -> Vec<Variable> {
+        todo!()
+    }
+
+    fn from_variables_unsafe(variables: &[Variable]) -> Self {
+        todo!()
+    }
+
+    fn assert_is_valid<L: PlonkParameters<D>, const D: usize>(
+        &self,
+        builder: &mut CircuitBuilder<L, D>,
+    ) {
+        self.data.assert_is_valid(builder);
+        self.lens.assert_is_valid(builder);
+        self.len.assert_is_valid(builder);
+    }
+
+    fn elements<F: RichField>(value: Self::ValueType<F>) -> Vec<F> {
+        todo!()
+    }
+}
+
+impl From<MPTNodeFixedSize> for MPTVariable {
+    fn from(v: MPTNodeFixedSize) -> Self {
+        todo!()
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<MPTNodeFixedSize> for MPTVariable {
+    fn into(self) -> MPTNodeFixedSize {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MPTVariable;
+    use crate::backend::circuit::DefaultParameters;
+    use crate::prelude::*;
+
+    type L = DefaultParameters;
+    const D: usize = 2;
+
+    #[test]
+    fn test_mpt() {
+        // For now, this test just initializes the MPT variable without any checks whatsoever.
+        let mut builder = CircuitBuilder::<L, D>::new();
+
+        let mpt = builder.init::<MPTVariable>();
+
+        // TODO: This test is obviously incomplete.
+        // let y = builder.init::<BoolVariable>();
+
+        // let not_x = builder.not(x);
+        // let not_y = builder.not(y);
+        // let x_and_y = builder.and(x, y);
+        // let x_and_x = builder.and(x, x);
+        // let x_or_y = builder.or(x, y);
+        // let x_or_x = builder.or(x, x);
+        // let y_or_y = builder.or(y, y);
+        // let x_xor_y = builder.xor(x, y);
+        // let x_xor_x = builder.xor(x, x);
+        // let y_xor_y = builder.xor(y, y);
+
+        // let mut pw: PartialWitness<GoldilocksField> = PartialWitness::new();
+
+        // x.set(&mut pw, true);
+        // y.set(&mut pw, false);
+
+        // not_x.set(&mut pw, false);
+        // not_y.set(&mut pw, true);
+        // x_and_y.set(&mut pw, false);
+        // x_and_x.set(&mut pw, true);
+        // x_or_y.set(&mut pw, true);
+        // x_or_x.set(&mut pw, true);
+        // y_or_y.set(&mut pw, false);
+        // x_xor_y.set(&mut pw, true);
+        // x_xor_x.set(&mut pw, false);
+        // y_xor_y.set(&mut pw, false);
+
+        // let circuit = builder.build();
+        // let proof = circuit.data.prove(pw).unwrap();
+        // circuit.data.verify(proof).unwrap();
+    }
+}

--- a/plonky2x/core/src/lib.rs
+++ b/plonky2x/core/src/lib.rs
@@ -33,7 +33,7 @@ pub mod prelude {
     pub use crate::frontend::uint::uint64::U64Variable;
     pub use crate::frontend::vars::{
         ArrayVariable, BoolVariable, ByteVariable, Bytes32Variable, BytesVariable, CircuitVariable,
-        OutputVariableStream, U32Variable, ValueStream, Variable, VariableStream,
+        MPTVariable, OutputVariableStream, U32Variable, ValueStream, Variable, VariableStream,
     };
     pub use crate::utils::{address, bytes, bytes32, hex};
 }


### PR DESCRIPTION
My last PR https://github.com/succinctlabs/succinctx/pull/276 cleaned up and added some minor features to the verification code in vanilla Rust. This PR re-implements the same logic in the circuit language. 