### PR TITLE
fix: eddsa + sha512 pad fixes

### DIFF
--- a/plonky2x/core/src/frontend/ecc/curve25519/ed25519/eddsa.rs
+++ b/plonky2x/core/src/frontend/ecc/curve25519/ed25519/eddsa.rs
@@ -141,7 +141,6 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         signatures: ArrayVariable<EDDSASignatureVariable, NUM_SIGS>,
         pubkeys: ArrayVariable<CompressedEdwardsYVariable, NUM_SIGS>,
     ) {
-        self.watch(&messages, "messages");
         assert!(NUM_SIGS > 0 && NUM_SIGS <= MAX_NUM_SIGS);
         assert!(messages.len() == NUM_SIGS);
         if let Some(ref msg_lens) = message_byte_lengths {
@@ -168,7 +167,6 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
 
             let digest: BytesVariable<64>;
             if let Some(ref msg_lens) = message_byte_lengths {
-                self.watch(&msg_lens[i], "msg_len");
                 let const_64 = U32Variable::constant(self, 64);
                 let message_to_hash_len = self.add(msg_lens[i], const_64);
                 digest = self.curta_sha512_variable(&message_bytes, message_to_hash_len);

--- a/plonky2x/core/src/frontend/hash/sha/sha512/curta.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha512/curta.rs
@@ -125,7 +125,6 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         length: U32Variable,
     ) -> BytesVariable<64> {
         let last_chunk = self.compute_sha512_last_chunk(length);
-        self.watch(&last_chunk, "last_chunk");
 
         if self.sha512_accelerator.is_none() {
             self.sha512_accelerator = Some(SHA512Accelerator {
@@ -346,7 +345,7 @@ mod tests {
         let max_number_of_chunks = 1;
         let total_message_length = 128 * max_number_of_chunks;
 
-        for i in 0..total_message_length {
+        for i in 127 - 20..total_message_length + 1 {
             let mut rng = thread_rng();
             let total_message = (0..i).map(|_| rng.gen::<u8>()).collect::<Vec<_>>();
             let message = total_message

--- a/plonky2x/core/src/frontend/hash/sha/sha512/curta.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha512/curta.rs
@@ -125,6 +125,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         length: U32Variable,
     ) -> BytesVariable<64> {
         let last_chunk = self.compute_sha512_last_chunk(length);
+        self.watch(&last_chunk, "last_chunk");
 
         if self.sha512_accelerator.is_none() {
             self.sha512_accelerator = Some(SHA512Accelerator {
@@ -306,21 +307,53 @@ mod tests {
         setup_logger();
         let mut builder = DefaultBuilder::new();
 
-        let max_number_of_chunks = 20;
+        let max_number_of_chunks = 2;
         let total_message_length = 128 * max_number_of_chunks;
-        let max_len = (total_message_length - 18) / 128;
+        let max_len = total_message_length - 8;
 
         let mut rng = thread_rng();
         let total_message = (0..total_message_length)
             .map(|_| rng.gen::<u8>())
             .collect::<Vec<_>>();
+        let message = total_message
+            .iter()
+            .map(|b| builder.constant::<ByteVariable>(*b))
+            .collect::<Vec<_>>();
         for i in 0..max_len {
-            let message = &total_message[..i];
-            let expected_digest = sha512(message);
+            let expected_digest = sha512(&total_message[..i]);
+
+            let length = builder.constant::<U32Variable>(i as u32);
+
+            let digest = builder.curta_sha512_variable(&message, length);
+            let expected_digest = builder.constant::<BytesVariable<64>>(expected_digest);
+            builder.assert_is_equal(digest, expected_digest);
+        }
+
+        let circuit = builder.build();
+        let input = circuit.input();
+        let (proof, output) = circuit.prove(&input);
+        circuit.verify(&proof, &input, &output);
+    }
+
+    #[test]
+    #[cfg_attr(feature = "ci", ignore)]
+    fn test_sha512_variable_length_max_size() {
+        // This test checks that sha512_variable_pad works as intended, especially when the max
+        // input length is (length % 128 > 128 - 17).
+        setup_logger();
+        let mut builder = DefaultBuilder::new();
+
+        let max_number_of_chunks = 1;
+        let total_message_length = 128 * max_number_of_chunks;
+
+        for i in 0..total_message_length {
+            let mut rng = thread_rng();
+            let total_message = (0..i).map(|_| rng.gen::<u8>()).collect::<Vec<_>>();
             let message = total_message
                 .iter()
                 .map(|b| builder.constant::<ByteVariable>(*b))
                 .collect::<Vec<_>>();
+            let expected_digest = sha512(&total_message);
 
             let length = builder.constant::<U32Variable>(i as u32);
 

--- a/plonky2x/core/src/frontend/hash/sha/sha512/pad.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha512/pad.rs
@@ -68,7 +68,8 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         let last_chunk = self.compute_sha512_last_chunk(input_byte_length);
 
         // Extend input to size max_num_chunks * 128 before padding.
-        let max_num_chunks = ceil_div_usize(input.len(), SHA512_CHUNK_SIZE_BYTES_128);
+        let max_num_chunks = ceil_div_usize(input.len() + 17, SHA512_CHUNK_SIZE_BYTES_128);
+
         let mut padded_input = input.to_vec();
         padded_input.resize(max_num_chunks * SHA512_CHUNK_SIZE_BYTES_128, self.zero());
 

--- a/plonky2x/core/src/frontend/hash/sha/sha512/pad.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha512/pad.rs
@@ -67,9 +67,11 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
     ) -> Vec<ByteVariable> {
         let last_chunk = self.compute_sha512_last_chunk(input_byte_length);
 
-        // Extend input to size max_num_chunks * 128 before padding.
+        // Calculate the number of chunks needed to store the input. 17 is the number of bytes added
+        // by the padding and LE length representation.
         let max_num_chunks = ceil_div_usize(input.len() + 17, SHA512_CHUNK_SIZE_BYTES_128);
 
+        // Extend input to size max_num_chunks * 128 before padding.
         let mut padded_input = input.to_vec();
         padded_input.resize(max_num_chunks * SHA512_CHUNK_SIZE_BYTES_128, self.zero());
 


### PR DESCRIPTION
- `curta_eddsa_verify_sigs_conditional`

- Add test for `sha512_pad`. Previously, the `max_num_chunks` was calculated incorrectly.