### PR TITLE
feat(plonky2x): use `curta_sha256` in wrapper

### DIFF
--- a/plonky2x/core/src/backend/circuit/build.rs
+++ b/plonky2x/core/src/backend/circuit/build.rs
@@ -40,9 +40,11 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuild<L, D> {
         PublicInput::new(&self.io)
     }
 
+    /// Generates a proof for the circuit using a plonky2 partial witness. The proof can be verified
+    /// using `verify`.
     pub fn prove_with_partial_witness(
         &self,
-        inputs: PartialWitness<L::Field>,
+        pw: PartialWitness<L::Field>,
     ) -> (
         ProofWithPublicInputs<L::Field, L::Config, D>,
         PublicOutput<L, D>,
@@ -54,7 +56,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuild<L, D> {
         let start_time = Instant::now();
         trace!("generating witness...");
         let partition_witness = generate_witness(
-            inputs,
+            pw,
             &self.data.prover_only,
             &self.data.common,
             &self.async_hints,
@@ -95,10 +97,11 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuild<L, D> {
         self.prove_with_partial_witness(pw)
     }
 
-    /// Generates a proof for the circuit. The proof can be verified using `verify`.
-    pub async fn prove_async(
+    /// Generates a proof for the circuit using a plonky2 partial witness. The proof can be verified
+    /// using `verify`.
+    pub async fn prove_with_partial_witness_async(
         &self,
-        input: &PublicInput<L, D>,
+        pw: PartialWitness<L::Field>,
     ) -> (
         ProofWithPublicInputs<L::Field, L::Config, D>,
         PublicOutput<L, D>,
@@ -108,8 +111,6 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuild<L, D> {
             AlgebraicHasher<<L as PlonkParameters<D>>::Field>,
     {
         let start_time = tokio::time::Instant::now();
-        let mut pw = PartialWitness::new();
-        self.io.set_witness(&mut pw, input);
         trace!("generating witness...");
         let partition_witness = generate_witness_async(
             pw,
@@ -136,6 +137,23 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuild<L, D> {
             debug!("proving took: {:?}", elapsed_time);
             (proof_with_pis, output)
         })
+    }
+
+    /// Generates a proof for the circuit. The proof can be verified using `verify`.
+    pub async fn prove_async(
+        &self,
+        input: &PublicInput<L, D>,
+    ) -> (
+        ProofWithPublicInputs<L::Field, L::Config, D>,
+        PublicOutput<L, D>,
+    )
+    where
+        <<L as PlonkParameters<D>>::Config as GenericConfig<D>>::Hasher:
+            AlgebraicHasher<<L as PlonkParameters<D>>::Field>,
+    {
+        let mut pw = PartialWitness::new();
+        self.io.set_witness(&mut pw, input);
+        self.prove_with_partial_witness_async(pw).await
     }
 
     /// Verifies a proof for the circuit.

--- a/plonky2x/core/src/backend/circuit/build.rs
+++ b/plonky2x/core/src/backend/circuit/build.rs
@@ -40,10 +40,9 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuild<L, D> {
         PublicInput::new(&self.io)
     }
 
-    /// Generates a proof for the circuit. The proof can be verified using `verify`.
-    pub fn prove(
+    pub fn prove_with_partial_witness(
         &self,
-        input: &PublicInput<L, D>,
+        inputs: PartialWitness<L::Field>,
     ) -> (
         ProofWithPublicInputs<L::Field, L::Config, D>,
         PublicOutput<L, D>,
@@ -53,11 +52,9 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuild<L, D> {
             AlgebraicHasher<<L as PlonkParameters<D>>::Field>,
     {
         let start_time = Instant::now();
-        let mut pw = PartialWitness::new();
-        self.io.set_witness(&mut pw, input);
         trace!("generating witness...");
         let partition_witness = generate_witness(
-            pw,
+            inputs,
             &self.data.prover_only,
             &self.data.common,
             &self.async_hints,
@@ -79,6 +76,23 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuild<L, D> {
         let elapsed_time = start_time.elapsed();
         debug!("proving took: {:?}", elapsed_time);
         (proof_with_pis, output)
+    }
+
+    /// Generates a proof for the circuit. The proof can be verified using `verify`.
+    pub fn prove(
+        &self,
+        input: &PublicInput<L, D>,
+    ) -> (
+        ProofWithPublicInputs<L::Field, L::Config, D>,
+        PublicOutput<L, D>,
+    )
+    where
+        <<L as PlonkParameters<D>>::Config as GenericConfig<D>>::Hasher:
+            AlgebraicHasher<<L as PlonkParameters<D>>::Field>,
+    {
+        let mut pw = PartialWitness::new();
+        self.io.set_witness(&mut pw, input);
+        self.prove_with_partial_witness(pw)
     }
 
     /// Generates a proof for the circuit. The proof can be verified using `verify`.

--- a/plonky2x/core/src/backend/wrapper/wrap.rs
+++ b/plonky2x/core/src/backend/wrapper/wrap.rs
@@ -183,7 +183,7 @@ where
         );
         pw.set_proof_with_pis_target(&self.circuit_proof_target, inner_proof);
 
-        let hash_proof = self.hash_circuit.data.prove(pw)?;
+        let (hash_proof, _) = self.hash_circuit.prove_with_partial_witness(pw);
         self.hash_circuit.data.verify(hash_proof.clone())?;
         debug!("Successfully verified hash proof");
 

--- a/plonky2x/core/src/backend/wrapper/wrap.rs
+++ b/plonky2x/core/src/backend/wrapper/wrap.rs
@@ -71,8 +71,8 @@ where
         hash_builder.watch_slice(&input_bytes, "input_bytes");
         hash_builder.watch_slice(&output_bytes, "output_bytes");
 
-        let input_hash = hash_builder.sha256(&input_bytes);
-        let output_hash = hash_builder.sha256(&output_bytes);
+        let input_hash = hash_builder.curta_sha256(&input_bytes);
+        let output_hash = hash_builder.curta_sha256(&output_bytes);
 
         hash_builder.watch(&input_hash, "input_hash");
         hash_builder.watch(&output_hash, "output_hash");


### PR DESCRIPTION
## Overview
- Use `curta_sha256` in `plonky2x` wrapper to handle large public inputs better.
   - On Mac M2 Max for wrapping now takes ~4s, vs. ~2s before.
- Add `prove_with_partial_witness` and `prove_with_partial_witness_async` to `Plonky2x` circuits, allowing plonky2 `PartialWitness` to be used to generate proofs directly, without using `plonky2x` IO.
