### PR TITLE
feat: custom prover whitelist 

### DIFF
--- a/contracts/src/FunctionRegistry.sol
+++ b/contracts/src/FunctionRegistry.sol
@@ -11,6 +11,7 @@ abstract contract FunctionRegistry is IFunctionRegistry {
     mapping(bytes32 => address) public verifierOwners;
 
     /// @notice Registers a function, using a pre-deployed verifier.
+    /// @dev The _owner can be set to address 0 to remove any update capabilities.
     /// @param _owner The owner of the function.
     /// @param _verifier The address of the verifier.
     /// @param _salt The salt to use for calculating the function ID.
@@ -32,6 +33,7 @@ abstract contract FunctionRegistry is IFunctionRegistry {
     }
 
     /// @notice Registers a function, using CREATE2 to deploy the verifier.
+    /// @dev The _owner can be set to address 0 to remove any update capabilities.
     /// @param _owner The owner of the function.
     /// @param _bytecode The bytecode of the verifier.
     /// @param _salt The salt to use for calculating the function ID.

--- a/contracts/src/SuccinctGateway.sol
+++ b/contracts/src/SuccinctGateway.sol
@@ -283,6 +283,17 @@ contract SuccinctGateway is ISuccinctGateway, FunctionRegistry, TimelockedUpgrad
         emit Call(_functionId, inputHash, outputHash);
     }
 
+    /// @notice Sets the whitelist status for a function.
+    /// @param _functionId The function identifier.
+    /// @param _status The whitelist status to set.
+    function setWhitelistStatus(bytes32 _functionId, WhitelistStatus _status) external {
+        if (msg.sender != verifierOwners[_functionId]) {
+            revert NotFunctionOwner(msg.sender, verifierOwners[_functionId]);
+        }
+        whitelistStatus[_functionId] = _status;
+        emit WhitelistStatusUpdated(_functionId, _status);
+    }
+
     /// @notice Add a custom prover.
     /// @param _functionId The function identifier.
     /// @param _prover The address of the prover to add.
@@ -324,17 +335,6 @@ contract SuccinctGateway is ISuccinctGateway, FunctionRegistry, TimelockedUpgrad
     function setFeeVault(address _feeVault) external onlyGuardian {
         emit SetFeeVault(feeVault, _feeVault);
         feeVault = _feeVault;
-    }
-
-    /// @notice Sets the whitelist status for a function.
-    /// @param _functionId The function identifier.
-    /// @param _status The whitelist status to set.
-    function setWhitelistStatus(bytes32 _functionId, WhitelistStatus _status) external {
-        if (msg.sender != verifierOwners[_functionId]) {
-            revert NotFunctionOwner(msg.sender, verifierOwners[_functionId]);
-        }
-        whitelistStatus[_functionId] = _status;
-        emit WhitelistStatusUpdated(_functionId, _status);
     }
 
     /// @dev Computes a unique identifier for a request.

--- a/contracts/src/interfaces/ISuccinctGateway.sol
+++ b/contracts/src/interfaces/ISuccinctGateway.sol
@@ -22,39 +22,19 @@ interface ISuccinctGatewayEvents {
         uint256 feeAmount
     );
     event RequestFulfilled(
-        uint32 indexed nonce,
-        bytes32 indexed functionId,
-        bytes32 inputHash,
-        bytes32 outputHash
+        uint32 indexed nonce, bytes32 indexed functionId, bytes32 inputHash, bytes32 outputHash
     );
-    event Call(
-        bytes32 indexed functionId,
-        bytes32 inputHash,
-        bytes32 outputHash
-    );
+    event Call(bytes32 indexed functionId, bytes32 inputHash, bytes32 outputHash);
     event SetFeeVault(address indexed oldFeeVault, address indexed newFeeVault);
-    event ProverUpdated(
-        bytes32 indexed functionId,
-        address indexed prover,
-        bool added
-    );
+    event ProverUpdated(bytes32 indexed functionId, address indexed prover, bool added);
 }
 
 interface ISuccinctGatewayErrors {
-    error InvalidRequest(
-        uint32 nonce,
-        bytes32 expectedRequestHash,
-        bytes32 requestHash
-    );
+    error InvalidRequest(uint32 nonce, bytes32 expectedRequestHash, bytes32 requestHash);
     error CallbackFailed(bytes4 callbackSelector, bytes output, bytes context);
     error InvalidCall(bytes32 functionId, bytes input);
     error CallFailed(address callbackAddress, bytes callbackData);
-    error InvalidProof(
-        address verifier,
-        bytes32 inputHash,
-        bytes32 outputHash,
-        bytes proof
-    );
+    error InvalidProof(address verifier, bytes32 inputHash, bytes32 outputHash, bytes proof);
     error ReentrantFulfill();
     error OnlyProver(bytes32 functionId, address sender);
 }
@@ -76,10 +56,10 @@ interface ISuccinctGateway is ISuccinctGatewayEvents, ISuccinctGatewayErrors {
         uint32 entryGasLimit
     ) external payable;
 
-    function verifiedCall(
-        bytes32 functionId,
-        bytes memory input
-    ) external view returns (bytes memory);
+    function verifiedCall(bytes32 functionId, bytes memory input)
+        external
+        view
+        returns (bytes memory);
 
     function isCallback() external view returns (bool);
 }

--- a/contracts/src/interfaces/ISuccinctGateway.sol
+++ b/contracts/src/interfaces/ISuccinctGateway.sol
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
+enum WhitelistStatus {
+    Default,
+    Custom,
+    Disabled
+}
+
 interface ISuccinctGatewayEvents {
     event RequestCallback(
         uint32 indexed nonce,
@@ -27,6 +33,7 @@ interface ISuccinctGatewayEvents {
     event Call(bytes32 indexed functionId, bytes32 inputHash, bytes32 outputHash);
     event SetFeeVault(address indexed oldFeeVault, address indexed newFeeVault);
     event ProverUpdated(bytes32 indexed functionId, address indexed prover, bool added);
+    event WhitelistStatusUpdated(bytes32 indexed functionId, WhitelistStatus status);
 }
 
 interface ISuccinctGatewayErrors {

--- a/contracts/src/interfaces/ISuccinctGateway.sol
+++ b/contracts/src/interfaces/ISuccinctGateway.sol
@@ -22,21 +22,41 @@ interface ISuccinctGatewayEvents {
         uint256 feeAmount
     );
     event RequestFulfilled(
-        uint32 indexed nonce, bytes32 indexed functionId, bytes32 inputHash, bytes32 outputHash
+        uint32 indexed nonce,
+        bytes32 indexed functionId,
+        bytes32 inputHash,
+        bytes32 outputHash
     );
-    event Call(bytes32 indexed functionId, bytes32 inputHash, bytes32 outputHash);
+    event Call(
+        bytes32 indexed functionId,
+        bytes32 inputHash,
+        bytes32 outputHash
+    );
     event SetFeeVault(address indexed oldFeeVault, address indexed newFeeVault);
-    event ProverUpdated(address indexed prover, bool added);
+    event ProverUpdated(
+        bytes32 indexed functionId,
+        address indexed prover,
+        bool added
+    );
 }
 
 interface ISuccinctGatewayErrors {
-    error InvalidRequest(uint32 nonce, bytes32 expectedRequestHash, bytes32 requestHash);
+    error InvalidRequest(
+        uint32 nonce,
+        bytes32 expectedRequestHash,
+        bytes32 requestHash
+    );
     error CallbackFailed(bytes4 callbackSelector, bytes output, bytes context);
     error InvalidCall(bytes32 functionId, bytes input);
     error CallFailed(address callbackAddress, bytes callbackData);
-    error InvalidProof(address verifier, bytes32 inputHash, bytes32 outputHash, bytes proof);
+    error InvalidProof(
+        address verifier,
+        bytes32 inputHash,
+        bytes32 outputHash,
+        bytes proof
+    );
     error ReentrantFulfill();
-    error OnlyProver(address sender);
+    error OnlyProver(bytes32 functionId, address sender);
 }
 
 interface ISuccinctGateway is ISuccinctGatewayEvents, ISuccinctGatewayErrors {
@@ -56,10 +76,10 @@ interface ISuccinctGateway is ISuccinctGatewayEvents, ISuccinctGatewayErrors {
         uint32 entryGasLimit
     ) external payable;
 
-    function verifiedCall(bytes32 functionId, bytes memory input)
-        external
-        view
-        returns (bytes memory);
+    function verifiedCall(
+        bytes32 functionId,
+        bytes memory input
+    ) external view returns (bytes memory);
 
     function isCallback() external view returns (bool);
 }

--- a/contracts/test/SuccinctGateway.t.sol
+++ b/contracts/test/SuccinctGateway.t.sol
@@ -6,19 +6,29 @@ import "forge-std/console.sol";
 import "forge-std/Test.sol";
 
 import {SuccinctGateway} from "src/SuccinctGateway.sol";
-import {ISuccinctGateway, ISuccinctGatewayEvents, ISuccinctGatewayErrors} from "src/interfaces/ISuccinctGateway.sol";
-import {TestConsumer, AttackConsumer, TestFunctionVerifier1, TestFunctionVerifier2} from "test/TestUtils.sol";
-import {IFunctionRegistry, IFunctionRegistryEvents, IFunctionRegistryErrors} from "src/interfaces/IFunctionRegistry.sol";
+import {
+    ISuccinctGateway,
+    ISuccinctGatewayEvents,
+    ISuccinctGatewayErrors
+} from "src/interfaces/ISuccinctGateway.sol";
+import {
+    TestConsumer,
+    AttackConsumer,
+    TestFunctionVerifier1,
+    TestFunctionVerifier2
+} from "test/TestUtils.sol";
+import {
+    IFunctionRegistry,
+    IFunctionRegistryEvents,
+    IFunctionRegistryErrors
+} from "src/interfaces/IFunctionRegistry.sol";
 import {TestConsumer, TestFunctionVerifier1} from "test/TestUtils.sol";
 import {Proxy} from "src/upgrades/Proxy.sol";
 import {SuccinctFeeVault} from "src/payments/SuccinctFeeVault.sol";
-import {AccessControlUpgradeable} from "@openzeppelin-upgradeable/contracts/access/AccessControlUpgradeable.sol";
+import {AccessControlUpgradeable} from
+    "@openzeppelin-upgradeable/contracts/access/AccessControlUpgradeable.sol";
 
-contract SuccinctGatewayTest is
-    Test,
-    ISuccinctGatewayEvents,
-    ISuccinctGatewayErrors
-{
+contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayErrors {
     // Example Function Request and expected values.
     bytes internal constant INPUT = bytes("function-input");
     bytes32 internal constant INPUT_HASH = sha256(INPUT);
@@ -63,17 +73,12 @@ contract SuccinctGatewayTest is
         // Deploy Verifier
         bytes32 functionId;
         vm.prank(sender);
-        (functionId, verifier) = IFunctionRegistry(gateway)
-            .deployAndRegisterFunction(
-                owner,
-                type(TestFunctionVerifier1).creationCode,
-                "test-verifier"
-            );
+        (functionId, verifier) = IFunctionRegistry(gateway).deployAndRegisterFunction(
+            owner, type(TestFunctionVerifier1).creationCode, "test-verifier"
+        );
 
         // Deploy TestConsumer
-        consumer = payable(
-            address(new TestConsumer(gateway, functionId, INPUT))
-        );
+        consumer = payable(address(new TestConsumer(gateway, functionId, INPUT)));
 
         vm.deal(sender, DEFAULT_FEE);
         vm.deal(consumer, DEFAULT_FEE);
@@ -85,22 +90,9 @@ contract SetupTest is SuccinctGatewayTest {
         bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
         assertEq(IFunctionRegistry(gateway).verifiers(functionId), verifier);
         assertEq(IFunctionRegistry(gateway).verifierOwners(functionId), owner);
-        assertEq(
-            SuccinctGateway(gateway).allowedProvers(bytes32(0), prover),
-            true
-        );
-        assertTrue(
-            AccessControlUpgradeable(gateway).hasRole(
-                keccak256("TIMELOCK_ROLE"),
-                timelock
-            )
-        );
-        assertTrue(
-            AccessControlUpgradeable(gateway).hasRole(
-                keccak256("GUARDIAN_ROLE"),
-                guardian
-            )
-        );
+        assertEq(SuccinctGateway(gateway).allowedProvers(bytes32(0), prover), true);
+        assertTrue(AccessControlUpgradeable(gateway).hasRole(keccak256("TIMELOCK_ROLE"), timelock));
+        assertTrue(AccessControlUpgradeable(gateway).hasRole(keccak256("GUARDIAN_ROLE"), guardian));
     }
 }
 
@@ -325,23 +317,13 @@ contract RequestTest is SuccinctGatewayTest {
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(
-            TestConsumer.handleCall.selector
-        );
+        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
         uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
         uint256 fee = DEFAULT_FEE;
 
         // Request
         vm.expectEmit(true, true, true, true, gateway);
-        emit RequestCall(
-            functionId,
-            input,
-            callAddress,
-            callData,
-            callGasLimit,
-            consumer,
-            fee
-        );
+        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
         TestConsumer(consumer).requestCall{value: fee}();
 
         assertEq(TestConsumer(consumer).handledRequests(0), false);
@@ -351,12 +333,7 @@ contract RequestTest is SuccinctGatewayTest {
         emit Call(functionId, INPUT_HASH, OUTPUT_HASH);
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId,
-            input,
-            output,
-            proof,
-            callAddress,
-            callData
+            functionId, input, output, proof, callAddress, callData
         );
 
         assertEq(TestConsumer(consumer).handledRequests(0), true);
@@ -368,19 +345,12 @@ contract RequestTest is SuccinctGatewayTest {
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(
-            TestConsumer.handleCall.selector
-        );
+        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
 
         // Fulfill
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId,
-            input,
-            output,
-            proof,
-            callAddress,
-            callData
+            functionId, input, output, proof, callAddress, callData
         );
     }
 
@@ -390,23 +360,13 @@ contract RequestTest is SuccinctGatewayTest {
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(
-            TestConsumer.handleCall.selector
-        );
+        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
         uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
         uint256 fee = 0;
 
         // Request
         vm.expectEmit(true, true, true, true, gateway);
-        emit RequestCall(
-            functionId,
-            input,
-            callAddress,
-            callData,
-            callGasLimit,
-            consumer,
-            fee
-        );
+        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
         TestConsumer(consumer).requestCall{value: fee}();
 
         assertEq(TestConsumer(consumer).handledRequests(0), false);
@@ -416,12 +376,7 @@ contract RequestTest is SuccinctGatewayTest {
         emit Call(functionId, INPUT_HASH, OUTPUT_HASH);
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId,
-            input,
-            output,
-            proof,
-            callAddress,
-            callData
+            functionId, input, output, proof, callAddress, callData
         );
 
         assertEq(TestConsumer(consumer).handledRequests(0), true);
@@ -436,23 +391,13 @@ contract RequestTest is SuccinctGatewayTest {
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(
-            TestConsumer.handleCall.selector
-        );
+        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
         uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
         uint256 fee = DEFAULT_FEE;
 
         // Request
         vm.expectEmit(true, true, true, true, gateway);
-        emit RequestCall(
-            functionId,
-            input,
-            callAddress,
-            callData,
-            callGasLimit,
-            consumer,
-            fee
-        );
+        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
         TestConsumer(consumer).requestCall{value: fee}();
 
         assertEq(TestConsumer(consumer).handledRequests(0), false);
@@ -462,12 +407,7 @@ contract RequestTest is SuccinctGatewayTest {
         emit Call(functionId, INPUT_HASH, OUTPUT_HASH);
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId,
-            input,
-            output,
-            proof,
-            callAddress,
-            callData
+            functionId, input, output, proof, callAddress, callData
         );
 
         assertEq(TestConsumer(consumer).handledRequests(0), true);
@@ -479,9 +419,7 @@ contract RequestTest is SuccinctGatewayTest {
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(
-            TestConsumer.handleCall.selector
-        );
+        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
         uint256 fee = DEFAULT_FEE;
 
         // Request
@@ -491,12 +429,7 @@ contract RequestTest is SuccinctGatewayTest {
         vm.expectRevert(abi.encodeWithSelector(OnlyProver.selector, sender));
         vm.prank(sender);
         SuccinctGateway(gateway).fulfillCall(
-            functionId,
-            input,
-            output,
-            proof,
-            callAddress,
-            callData
+            functionId, input, output, proof, callAddress, callData
         );
     }
 
@@ -520,9 +453,7 @@ contract RequestTest is SuccinctGatewayTest {
         bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
 
         // Verify call
-        vm.expectRevert(
-            abi.encodeWithSelector(InvalidCall.selector, functionId, input)
-        );
+        vm.expectRevert(abi.encodeWithSelector(InvalidCall.selector, functionId, input));
         TestConsumer(consumer).verifiedCall();
     }
 }
@@ -536,17 +467,12 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         // Deploy Verifier
         bytes32 functionId;
         vm.prank(sender);
-        (functionId, verifier) = IFunctionRegistry(gateway)
-            .deployAndRegisterFunction(
-                owner,
-                type(TestFunctionVerifier1).creationCode,
-                "attack-verifier"
-            );
+        (functionId, verifier) = IFunctionRegistry(gateway).deployAndRegisterFunction(
+            owner, type(TestFunctionVerifier1).creationCode, "attack-verifier"
+        );
 
         // Deploy AttackConsumer
-        attackConsumer = payable(
-            address(new AttackConsumer(gateway, functionId, INPUT))
-        );
+        attackConsumer = payable(address(new AttackConsumer(gateway, functionId, INPUT)));
 
         vm.deal(attackConsumer, DEFAULT_FEE);
     }
@@ -557,18 +483,13 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         bytes32 functionId = AttackConsumer(attackConsumer).FUNCTION_ID();
         bytes32 inputHash = INPUT_HASH;
         address callbackAddress = attackConsumer;
-        bytes4 callbackSelector = AttackConsumer
-            .handleCallbackReenterCallback
-            .selector;
-        uint32 callbackGasLimit = AttackConsumer(attackConsumer)
-            .CALLBACK_GAS_LIMIT();
+        bytes4 callbackSelector = AttackConsumer.handleCallbackReenterCallback.selector;
+        uint32 callbackGasLimit = AttackConsumer(attackConsumer).CALLBACK_GAS_LIMIT();
         uint256 fee = DEFAULT_FEE;
 
         // Request
         vm.prank(sender);
-        AttackConsumer(attackConsumer).requestCallbackReenterCallback{
-            value: fee
-        }();
+        AttackConsumer(attackConsumer).requestCallbackReenterCallback{value: fee}();
 
         // Fulfill (test fails this doesn't revert with ReentrantFulfill() error)
         vm.prank(prover);
@@ -591,11 +512,8 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         bytes32 functionId = AttackConsumer(attackConsumer).FUNCTION_ID();
         bytes32 inputHash = INPUT_HASH;
         address callbackAddress = attackConsumer;
-        bytes4 callbackSelector = AttackConsumer
-            .handleCallbackReenterCall
-            .selector;
-        uint32 callbackGasLimit = AttackConsumer(attackConsumer)
-            .CALLBACK_GAS_LIMIT();
+        bytes4 callbackSelector = AttackConsumer.handleCallbackReenterCall.selector;
+        uint32 callbackGasLimit = AttackConsumer(attackConsumer).CALLBACK_GAS_LIMIT();
         uint256 fee = DEFAULT_FEE;
 
         // Request
@@ -623,9 +541,8 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         bytes memory proof = PROOF;
         bytes32 functionId = AttackConsumer(attackConsumer).FUNCTION_ID();
         address callAddress = attackConsumer;
-        bytes memory callData = abi.encodeWithSelector(
-            AttackConsumer.handleCallReenterCallback.selector
-        );
+        bytes memory callData =
+            abi.encodeWithSelector(AttackConsumer.handleCallReenterCallback.selector);
         uint256 fee = DEFAULT_FEE;
 
         // Request
@@ -635,12 +552,7 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         // Fulfill (test fails this doesn't revert with ReentrantFulfill() error)
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId,
-            input,
-            output,
-            proof,
-            callAddress,
-            callData
+            functionId, input, output, proof, callAddress, callData
         );
     }
 
@@ -650,9 +562,8 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         bytes memory proof = PROOF;
         bytes32 functionId = AttackConsumer(attackConsumer).FUNCTION_ID();
         address callAddress = attackConsumer;
-        bytes memory callData = abi.encodeWithSelector(
-            AttackConsumer.handleCallReenterCall.selector
-        );
+        bytes memory callData =
+            abi.encodeWithSelector(AttackConsumer.handleCallReenterCall.selector);
         uint256 fee = DEFAULT_FEE;
 
         // Request
@@ -662,12 +573,7 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         // Fulfill (test fails this doesn't revert with ReentrantFulfill() error)
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId,
-            input,
-            output,
-            proof,
-            callAddress,
-            callData
+            functionId, input, output, proof, callAddress, callData
         );
     }
 }
@@ -678,10 +584,8 @@ contract FunctionRegistryTest is
     IFunctionRegistryErrors
 {
     function test_RegisterFunction() public {
-        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
-            owner,
-            "test-verifier1"
-        );
+        bytes32 expectedFunctionId1 =
+            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
 
         // Deploy verifier
         address verifier1;
@@ -693,34 +597,18 @@ contract FunctionRegistryTest is
 
         // Register function
         vm.expectEmit(true, true, true, true, gateway);
-        emit FunctionRegistered(
-            expectedFunctionId1,
-            verifier1,
-            "test-verifier1",
-            owner
-        );
-        bytes32 functionId1 = IFunctionRegistry(gateway).registerFunction(
-            owner,
-            verifier1,
-            "test-verifier1"
-        );
+        emit FunctionRegistered(expectedFunctionId1, verifier1, "test-verifier1", owner);
+        bytes32 functionId1 =
+            IFunctionRegistry(gateway).registerFunction(owner, verifier1, "test-verifier1");
 
         assertEq(functionId1, expectedFunctionId1);
-        assertEq(
-            IFunctionRegistry(gateway).verifiers(expectedFunctionId1),
-            verifier1
-        );
-        assertEq(
-            IFunctionRegistry(gateway).verifierOwners(expectedFunctionId1),
-            owner
-        );
+        assertEq(IFunctionRegistry(gateway).verifiers(expectedFunctionId1), verifier1);
+        assertEq(IFunctionRegistry(gateway).verifierOwners(expectedFunctionId1), owner);
     }
 
     function test_RegisterFunction_WhenOwnerIsSender() public {
-        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
-            owner,
-            "test-verifier1"
-        );
+        bytes32 expectedFunctionId1 =
+            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
 
         // Deploy verifier
         address verifier1;
@@ -732,38 +620,21 @@ contract FunctionRegistryTest is
 
         // Register function
         vm.expectEmit(true, true, true, true, gateway);
-        emit FunctionRegistered(
-            expectedFunctionId1,
-            verifier1,
-            "test-verifier1",
-            owner
-        );
+        emit FunctionRegistered(expectedFunctionId1, verifier1, "test-verifier1", owner);
         vm.prank(owner);
-        bytes32 functionId1 = IFunctionRegistry(gateway).registerFunction(
-            owner,
-            verifier1,
-            "test-verifier1"
-        );
+        bytes32 functionId1 =
+            IFunctionRegistry(gateway).registerFunction(owner, verifier1, "test-verifier1");
 
         assertEq(functionId1, expectedFunctionId1);
-        assertEq(
-            IFunctionRegistry(gateway).verifiers(expectedFunctionId1),
-            verifier1
-        );
-        assertEq(
-            IFunctionRegistry(gateway).verifierOwners(expectedFunctionId1),
-            owner
-        );
+        assertEq(IFunctionRegistry(gateway).verifiers(expectedFunctionId1), verifier1);
+        assertEq(IFunctionRegistry(gateway).verifierOwners(expectedFunctionId1), owner);
     }
 
     function test_RevertRegisterFunction_WhenAlreadyRegistered() public {
         // Deploy verifier
         address verifier1;
         bytes memory bytecode = type(TestFunctionVerifier1).creationCode;
-        bytes32 salt = IFunctionRegistry(gateway).getFunctionId(
-            owner,
-            "test-verifier1"
-        );
+        bytes32 salt = IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
         assembly {
             verifier1 := create2(0, add(bytecode, 32), mload(bytecode), salt)
         }
@@ -771,49 +642,28 @@ contract FunctionRegistryTest is
         // Register function
         vm.expectEmit(true, true, true, true, gateway);
         emit FunctionRegistered(salt, verifier1, "test-verifier1", owner);
-        IFunctionRegistry(gateway).registerFunction(
-            owner,
-            verifier1,
-            "test-verifier1"
-        );
+        IFunctionRegistry(gateway).registerFunction(owner, verifier1, "test-verifier1");
 
         // Register function again
-        vm.expectRevert(
-            abi.encodeWithSelector(FunctionAlreadyRegistered.selector, salt)
-        );
-        IFunctionRegistry(gateway).registerFunction(
-            owner,
-            verifier1,
-            "test-verifier1"
-        );
+        vm.expectRevert(abi.encodeWithSelector(FunctionAlreadyRegistered.selector, salt));
+        IFunctionRegistry(gateway).registerFunction(owner, verifier1, "test-verifier1");
     }
 
     function test_DeployAndRegisterFunction() public {
-        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
-            owner,
-            "test-verifier1"
-        );
+        bytes32 expectedFunctionId1 =
+            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
 
         // Deploy verifier and register function
         vm.expectEmit(true, false, false, true, gateway);
         emit Deployed(
-            keccak256(type(TestFunctionVerifier1).creationCode),
-            expectedFunctionId1,
-            address(0)
+            keccak256(type(TestFunctionVerifier1).creationCode), expectedFunctionId1, address(0)
         );
         vm.expectEmit(true, true, true, false, gateway);
-        emit FunctionRegistered(
-            expectedFunctionId1,
-            address(0),
-            "test-verifier1",
-            owner
-        );
+        emit FunctionRegistered(expectedFunctionId1, address(0), "test-verifier1", owner);
         (bytes32 functionId1, address verifier1) = IFunctionRegistry(gateway)
             .deployAndRegisterFunction(
-                owner,
-                type(TestFunctionVerifier1).creationCode,
-                "test-verifier1"
-            );
+            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
+        );
 
         assertEq(functionId1, expectedFunctionId1);
         assertEq(IFunctionRegistry(gateway).verifiers(functionId1), verifier1);
@@ -821,74 +671,47 @@ contract FunctionRegistryTest is
     }
 
     function test_DeployAndRegisterFunction_WhenOwnerIsSender() public {
-        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
-            owner,
-            "test-verifier1"
-        );
+        bytes32 expectedFunctionId1 =
+            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
 
         // Deploy verifier and register function
         vm.expectEmit(true, false, false, true, gateway);
         emit Deployed(
-            keccak256(type(TestFunctionVerifier1).creationCode),
-            expectedFunctionId1,
-            address(0)
+            keccak256(type(TestFunctionVerifier1).creationCode), expectedFunctionId1, address(0)
         );
         vm.expectEmit(true, true, true, false, gateway);
-        emit FunctionRegistered(
-            expectedFunctionId1,
-            address(0),
-            "test-verifier1",
-            owner
-        );
+        emit FunctionRegistered(expectedFunctionId1, address(0), "test-verifier1", owner);
         vm.prank(owner);
         (bytes32 functionId1, address verifier1) = IFunctionRegistry(gateway)
             .deployAndRegisterFunction(
-                owner,
-                type(TestFunctionVerifier1).creationCode,
-                "test-verifier1"
-            );
+            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
+        );
 
         assertEq(functionId1, expectedFunctionId1);
         assertEq(IFunctionRegistry(gateway).verifiers(functionId1), verifier1);
         assertEq(IFunctionRegistry(gateway).verifierOwners(functionId1), owner);
     }
 
-    function test_RevertDeployAndRegisterFunction_WhenAlreadyRegistered()
-        public
-    {
+    function test_RevertDeployAndRegisterFunction_WhenAlreadyRegistered() public {
         // Deploy verifier and register function
-        (bytes32 functionId1, ) = IFunctionRegistry(gateway)
-            .deployAndRegisterFunction(
-                owner,
-                type(TestFunctionVerifier1).creationCode,
-                "test-verifier1"
-            );
+        (bytes32 functionId1,) = IFunctionRegistry(gateway).deployAndRegisterFunction(
+            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
+        );
 
         // Deploy verifier and register function again
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                FunctionAlreadyRegistered.selector,
-                functionId1
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(FunctionAlreadyRegistered.selector, functionId1));
         IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner,
-            type(TestFunctionVerifier1).creationCode,
-            "test-verifier1"
+            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
         );
     }
 
     function test_UpdateFunction() public {
-        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
-            owner,
-            "test-verifier1"
-        );
+        bytes32 expectedFunctionId1 =
+            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
 
         // Deploy verifier and register function
         IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner,
-            type(TestFunctionVerifier1).creationCode,
-            "test-verifier1"
+            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
         );
 
         // Deploy verifier
@@ -903,10 +726,7 @@ contract FunctionRegistryTest is
         vm.expectEmit(true, true, true, true, gateway);
         emit FunctionVerifierUpdated(expectedFunctionId1, verifier2);
         vm.prank(owner);
-        bytes32 functionId1 = IFunctionRegistry(gateway).updateFunction(
-            verifier2,
-            "test-verifier1"
-        );
+        bytes32 functionId1 = IFunctionRegistry(gateway).updateFunction(verifier2, "test-verifier1");
 
         assertEq(functionId1, expectedFunctionId1);
         assertEq(IFunctionRegistry(gateway).verifiers(functionId1), verifier2);
@@ -915,12 +735,9 @@ contract FunctionRegistryTest is
 
     function test_RevertUpdateFunction_WhenNotOwner() public {
         // Deploy verifier and register function
-        (bytes32 functionId, ) = IFunctionRegistry(gateway)
-            .deployAndRegisterFunction(
-                owner,
-                type(TestFunctionVerifier1).creationCode,
-                "test-verifier1"
-            );
+        (bytes32 functionId,) = IFunctionRegistry(gateway).deployAndRegisterFunction(
+            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
+        );
 
         // Deploy verifier
         address verifier2;
@@ -932,13 +749,7 @@ contract FunctionRegistryTest is
 
         // Update function
         vm.prank(sender);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                NotFunctionOwner.selector,
-                sender,
-                address(0)
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(NotFunctionOwner.selector, sender, address(0)));
         IFunctionRegistry(gateway).updateFunction(verifier2, "test-verifier1");
     }
 
@@ -952,9 +763,7 @@ contract FunctionRegistryTest is
         }
 
         // Update function
-        vm.expectRevert(
-            abi.encodeWithSelector(NotFunctionOwner.selector, owner, address(0))
-        );
+        vm.expectRevert(abi.encodeWithSelector(NotFunctionOwner.selector, owner, address(0)));
         vm.prank(owner);
         IFunctionRegistry(gateway).updateFunction(verifier2, "test-verifier1");
     }
@@ -963,47 +772,34 @@ contract FunctionRegistryTest is
         // Deploy verifier and register function
         (bytes32 functionId1, address verifier1) = IFunctionRegistry(gateway)
             .deployAndRegisterFunction(
-                owner,
-                type(TestFunctionVerifier1).creationCode,
-                "test-verifier1"
-            );
+            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
+        );
 
         // Update function
-        vm.expectRevert(
-            abi.encodeWithSelector(VerifierAlreadyUpdated.selector, functionId1)
-        );
+        vm.expectRevert(abi.encodeWithSelector(VerifierAlreadyUpdated.selector, functionId1));
         vm.prank(owner);
         IFunctionRegistry(gateway).updateFunction(verifier1, "test-verifier1");
     }
 
     function test_deployAndUpdateFunction() public {
-        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
-            owner,
-            "test-verifier1"
-        );
+        bytes32 expectedFunctionId1 =
+            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
 
         // Deploy verifier and register function
         IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner,
-            type(TestFunctionVerifier1).creationCode,
-            "test-verifier1"
+            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
         );
 
         // Deploy verifier and update function
         vm.expectEmit(true, false, false, true, gateway);
         emit Deployed(
-            keccak256(type(TestFunctionVerifier2).creationCode),
-            expectedFunctionId1,
-            address(0)
+            keccak256(type(TestFunctionVerifier2).creationCode), expectedFunctionId1, address(0)
         );
         vm.expectEmit(true, true, true, false, gateway);
         emit FunctionVerifierUpdated(expectedFunctionId1, address(0));
         vm.prank(owner);
         (bytes32 functionId1, address verifier2) = IFunctionRegistry(gateway)
-            .deployAndUpdateFunction(
-                type(TestFunctionVerifier2).creationCode,
-                "test-verifier1"
-            );
+            .deployAndUpdateFunction(type(TestFunctionVerifier2).creationCode, "test-verifier1");
 
         assertEq(functionId1, expectedFunctionId1);
         assertEq(IFunctionRegistry(gateway).verifiers(functionId1), verifier2);
@@ -1013,52 +809,37 @@ contract FunctionRegistryTest is
     function test_RevertDeployAndUpdateFunction_WhenNotOwner() public {
         // Deploy verifier and register function
         IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner,
-            type(TestFunctionVerifier1).creationCode,
-            "test-verifier1"
+            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
         );
 
         // Deploy verifier and update function
         vm.prank(sender);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                NotFunctionOwner.selector,
-                sender,
-                address(0)
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(NotFunctionOwner.selector, sender, address(0)));
         IFunctionRegistry(gateway).deployAndUpdateFunction(
-            type(TestFunctionVerifier2).creationCode,
-            "test-verifier1"
+            type(TestFunctionVerifier2).creationCode, "test-verifier1"
         );
     }
 
     function test_RevertDeployAndUpdateFunction_WhenNeverRegistered() public {
         // Deploy verifier and update function
-        vm.expectRevert(
-            abi.encodeWithSelector(NotFunctionOwner.selector, owner, address(0))
-        );
+        vm.expectRevert(abi.encodeWithSelector(NotFunctionOwner.selector, owner, address(0)));
         vm.prank(owner);
         IFunctionRegistry(gateway).deployAndUpdateFunction(
-            type(TestFunctionVerifier1).creationCode,
-            "test-verifier1"
+            type(TestFunctionVerifier1).creationCode, "test-verifier1"
         );
     }
 
     function test_RevertDeployAndUpdateFunction_WhenBytecodeSame() public {
         // Deploy verifier and register function
         IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner,
-            type(TestFunctionVerifier1).creationCode,
-            "test-verifier1"
+            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
         );
 
         // Deploy verifier and update function
         vm.expectRevert(abi.encodeWithSelector(FailedDeploy.selector));
         vm.prank(owner);
         IFunctionRegistry(gateway).deployAndUpdateFunction(
-            type(TestFunctionVerifier1).creationCode,
-            "test-verifier1"
+            type(TestFunctionVerifier1).creationCode, "test-verifier1"
         );
     }
 }
@@ -1069,45 +850,29 @@ contract UpdateProverTest is SuccinctGatewayTest {
 
         vm.prank(guardian);
         SuccinctGateway(gateway).addProver(newProver);
-        assertEq(
-            SuccinctGateway(gateway).allowedProvers(bytes32(0), newProver),
-            true
-        );
+        assertEq(SuccinctGateway(gateway).allowedProvers(bytes32(0), newProver), true);
     }
 
     function test_RevertAddProver_WhenNotGuardian() public {
         address newProver = makeAddr("new-prover");
 
-        vm.expectRevert(
-            abi.encodeWithSignature("OnlyGuardian(address)", sender)
-        );
+        vm.expectRevert(abi.encodeWithSignature("OnlyGuardian(address)", sender));
         vm.prank(sender);
         SuccinctGateway(gateway).addProver(newProver);
-        assertEq(
-            SuccinctGateway(gateway).allowedProvers(bytes32(0), newProver),
-            false
-        );
+        assertEq(SuccinctGateway(gateway).allowedProvers(bytes32(0), newProver), false);
     }
 
     function test_RemoveProver() public {
         vm.prank(guardian);
         SuccinctGateway(gateway).removeProver(prover);
-        assertEq(
-            SuccinctGateway(gateway).allowedProvers(bytes32(0), prover),
-            false
-        );
+        assertEq(SuccinctGateway(gateway).allowedProvers(bytes32(0), prover), false);
     }
 
     function test_RevertRemoveProver_WhenNotGuardian() public {
-        vm.expectRevert(
-            abi.encodeWithSignature("OnlyGuardian(address)", sender)
-        );
+        vm.expectRevert(abi.encodeWithSignature("OnlyGuardian(address)", sender));
         vm.prank(sender);
         SuccinctGateway(gateway).removeProver(prover);
-        assertEq(
-            SuccinctGateway(gateway).allowedProvers(bytes32(0), prover),
-            true
-        );
+        assertEq(SuccinctGateway(gateway).allowedProvers(bytes32(0), prover), true);
     }
 }
 
@@ -1116,9 +881,7 @@ contract SetFeeVaultTest is SuccinctGatewayTest {
         bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
         bytes memory input = INPUT;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(
-            TestConsumer.handleCall.selector
-        );
+        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
         uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
         uint256 fee = DEFAULT_FEE;
         address newFeeVault = address(new SuccinctFeeVault());
@@ -1133,15 +896,7 @@ contract SetFeeVaultTest is SuccinctGatewayTest {
 
         // Request with fee
         vm.expectEmit(true, true, true, true, gateway);
-        emit RequestCall(
-            functionId,
-            input,
-            callAddress,
-            callData,
-            callGasLimit,
-            consumer,
-            fee
-        );
+        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
         TestConsumer(consumer).requestCall{value: fee}();
     }
 

--- a/contracts/test/SuccinctGateway.t.sol
+++ b/contracts/test/SuccinctGateway.t.sol
@@ -7,6 +7,7 @@ import "forge-std/Test.sol";
 
 import {SuccinctGateway} from "src/SuccinctGateway.sol";
 import {
+    WhitelistStatus,
     ISuccinctGateway,
     ISuccinctGatewayEvents,
     ISuccinctGatewayErrors
@@ -68,7 +69,7 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
 
         // Add prover
         vm.prank(guardian);
-        SuccinctGateway(gateway).addProver(prover);
+        SuccinctGateway(gateway).addDefaultProver(prover);
 
         // Deploy Verifier
         bytes32 functionId;
@@ -134,6 +135,119 @@ contract RequestTest is SuccinctGatewayTest {
         vm.expectEmit(true, true, true, true, gateway);
         emit RequestFulfilled(nonce, functionId, inputHash, OUTPUT_HASH);
         vm.prank(prover);
+        SuccinctGateway(gateway).fulfillCallback(
+            nonce,
+            functionId,
+            inputHash,
+            callbackAddress,
+            callbackSelector,
+            callbackGasLimit,
+            context,
+            output,
+            proof
+        );
+
+        assertEq(TestConsumer(consumer).handledRequests(0), true);
+    }
+
+    function test_Callback_WhenCustomProver() public {
+        address customProver = makeAddr("custom-prover");
+
+        uint32 prevNonce = SuccinctGateway(gateway).nonce();
+        assertEq(prevNonce, 0);
+
+        uint32 nonce = prevNonce;
+        bytes32 inputHash = INPUT_HASH;
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+        address callbackAddress = consumer;
+        bytes4 callbackSelector = TestConsumer.handleCallback.selector;
+        uint32 callbackGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
+        uint256 fee = DEFAULT_FEE;
+        bytes memory context = abi.encode(nonce);
+        bytes memory output = OUTPUT;
+        bytes memory proof = PROOF;
+
+        // Request
+        vm.expectEmit(true, true, true, true, gateway);
+        emit RequestCallback(
+            nonce,
+            functionId,
+            INPUT,
+            context,
+            callbackAddress,
+            callbackSelector,
+            callbackGasLimit,
+            fee
+        );
+        vm.prank(sender);
+        TestConsumer(consumer).requestCallback{value: fee}();
+
+        assertEq(prevNonce + 1, SuccinctGateway(gateway).nonce());
+        assertEq(TestConsumer(consumer).handledRequests(0), false);
+
+        vm.prank(owner);
+        SuccinctGateway(gateway).setWhitelistStatus(functionId, WhitelistStatus.Custom);
+        vm.prank(owner);
+        SuccinctGateway(gateway).addCustomProver(functionId, customProver);
+
+        // Fulfill
+        vm.expectEmit(true, true, true, true, gateway);
+        emit RequestFulfilled(nonce, functionId, inputHash, OUTPUT_HASH);
+        vm.prank(customProver);
+        SuccinctGateway(gateway).fulfillCallback(
+            nonce,
+            functionId,
+            inputHash,
+            callbackAddress,
+            callbackSelector,
+            callbackGasLimit,
+            context,
+            output,
+            proof
+        );
+
+        assertEq(TestConsumer(consumer).handledRequests(0), true);
+    }
+
+    function test_Callback_WhenDisabledProver() public {
+        uint32 prevNonce = SuccinctGateway(gateway).nonce();
+        assertEq(prevNonce, 0);
+
+        uint32 nonce = prevNonce;
+        bytes32 inputHash = INPUT_HASH;
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+        address callbackAddress = consumer;
+        bytes4 callbackSelector = TestConsumer.handleCallback.selector;
+        uint32 callbackGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
+        uint256 fee = DEFAULT_FEE;
+        bytes memory context = abi.encode(nonce);
+        bytes memory output = OUTPUT;
+        bytes memory proof = PROOF;
+
+        // Request
+        vm.expectEmit(true, true, true, true, gateway);
+        emit RequestCallback(
+            nonce,
+            functionId,
+            INPUT,
+            context,
+            callbackAddress,
+            callbackSelector,
+            callbackGasLimit,
+            fee
+        );
+        vm.prank(sender);
+        TestConsumer(consumer).requestCallback{value: fee}();
+
+        assertEq(prevNonce + 1, SuccinctGateway(gateway).nonce());
+        assertEq(TestConsumer(consumer).handledRequests(0), false);
+
+        vm.prank(owner);
+        SuccinctGateway(gateway).setWhitelistStatus(functionId, WhitelistStatus.Disabled);
+
+        // Fulfill
+        vm.expectEmit(true, true, true, true, gateway);
+        emit RequestFulfilled(nonce, functionId, inputHash, OUTPUT_HASH);
         SuccinctGateway(gateway).fulfillCallback(
             nonce,
             functionId,
@@ -296,7 +410,7 @@ contract RequestTest is SuccinctGatewayTest {
         TestConsumer(consumer).requestCallback{value: fee}();
 
         // Fulfill
-        vm.expectRevert(abi.encodeWithSelector(OnlyProver.selector, sender));
+        vm.expectRevert(abi.encodeWithSelector(OnlyProver.selector, functionId, sender));
         vm.prank(sender);
         SuccinctGateway(gateway).fulfillCallback(
             nonce,
@@ -426,7 +540,7 @@ contract RequestTest is SuccinctGatewayTest {
         TestConsumer(consumer).requestCall{value: fee}();
 
         // Fulfill
-        vm.expectRevert(abi.encodeWithSelector(OnlyProver.selector, sender));
+        vm.expectRevert(abi.encodeWithSelector(OnlyProver.selector, functionId, sender));
         vm.prank(sender);
         SuccinctGateway(gateway).fulfillCall(
             functionId, input, output, proof, callAddress, callData
@@ -845,34 +959,98 @@ contract FunctionRegistryTest is
 }
 
 contract UpdateProverTest is SuccinctGatewayTest {
-    function test_AddProver() public {
-        address newProver = makeAddr("new-prover");
+    function test_AddDefaultProver() public {
+        address defaultProver = makeAddr("default-prover");
 
+        vm.expectEmit(true, true, true, true, gateway);
+        emit ProverUpdated(bytes32(0), defaultProver, true);
         vm.prank(guardian);
-        SuccinctGateway(gateway).addProver(newProver);
-        assertEq(SuccinctGateway(gateway).allowedProvers(bytes32(0), newProver), true);
+        SuccinctGateway(gateway).addDefaultProver(defaultProver);
+        assertEq(SuccinctGateway(gateway).allowedProvers(bytes32(0), defaultProver), true);
     }
 
-    function test_RevertAddProver_WhenNotGuardian() public {
-        address newProver = makeAddr("new-prover");
+    function test_RevertAddDefaultProver_WhenNotGuardian() public {
+        address defaultProver = makeAddr("default-prover");
 
         vm.expectRevert(abi.encodeWithSignature("OnlyGuardian(address)", sender));
         vm.prank(sender);
-        SuccinctGateway(gateway).addProver(newProver);
-        assertEq(SuccinctGateway(gateway).allowedProvers(bytes32(0), newProver), false);
+        SuccinctGateway(gateway).addDefaultProver(defaultProver);
+        assertEq(SuccinctGateway(gateway).allowedProvers(bytes32(0), defaultProver), false);
     }
 
-    function test_RemoveProver() public {
+    function test_RemoveDefaultProver() public {
+        emit ProverUpdated(bytes32(0), prover, true);
         vm.prank(guardian);
-        SuccinctGateway(gateway).removeProver(prover);
+        SuccinctGateway(gateway).removeDefaultProver(prover);
         assertEq(SuccinctGateway(gateway).allowedProvers(bytes32(0), prover), false);
     }
 
-    function test_RevertRemoveProver_WhenNotGuardian() public {
+    function test_RevertRemoveDefaultProver_WhenNotGuardian() public {
         vm.expectRevert(abi.encodeWithSignature("OnlyGuardian(address)", sender));
         vm.prank(sender);
-        SuccinctGateway(gateway).removeProver(prover);
+        SuccinctGateway(gateway).removeDefaultProver(prover);
         assertEq(SuccinctGateway(gateway).allowedProvers(bytes32(0), prover), true);
+    }
+
+    function test_AddCustomProver() public {
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+        address customProver = makeAddr("custom-prover");
+
+        vm.expectEmit(true, true, true, true, gateway);
+        emit ProverUpdated(functionId, customProver, true);
+        vm.prank(owner);
+        SuccinctGateway(gateway).addCustomProver(functionId, customProver);
+        assertEq(SuccinctGateway(gateway).allowedProvers(functionId, customProver), true);
+    }
+
+    function test_RevertAddCustomProver_WhenNotOwner() public {
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+        address customProver = makeAddr("custom-prover");
+
+        vm.expectRevert(abi.encodeWithSignature("NotFunctionOwner(address,address)", sender, owner));
+        vm.prank(sender);
+        SuccinctGateway(gateway).addCustomProver(functionId, customProver);
+        assertEq(SuccinctGateway(gateway).allowedProvers(functionId, customProver), false);
+    }
+
+    function test_RemoveCustomProver() public {
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+
+        emit ProverUpdated(functionId, prover, true);
+        vm.prank(owner);
+        SuccinctGateway(gateway).removeCustomProver(functionId, prover);
+        assertEq(SuccinctGateway(gateway).allowedProvers(functionId, prover), false);
+    }
+
+    function test_RevertRemoveCustomProver_WhenNotOwner() public {
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+
+        vm.expectRevert(abi.encodeWithSignature("NotFunctionOwner(address,address)", sender, owner));
+        vm.prank(sender);
+        SuccinctGateway(gateway).removeCustomProver(functionId, prover);
+    }
+}
+
+contract SetWhitelistStatusTest is SuccinctGatewayTest {
+    function test_SetWhitelistStatus() public {
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+        WhitelistStatus status = WhitelistStatus.Custom;
+
+        vm.expectEmit(true, true, true, true, gateway);
+        emit WhitelistStatusUpdated(functionId, status);
+        vm.prank(owner);
+        SuccinctGateway(gateway).setWhitelistStatus(functionId, status);
+        assertTrue(SuccinctGateway(gateway).whitelistStatus(functionId) == status);
+    }
+
+    function test_RevertSetWhitelistStatus_WhenNotOwner() public {
+        bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
+        WhitelistStatus status = WhitelistStatus.Custom;
+
+        vm.expectRevert(abi.encodeWithSignature("NotFunctionOwner(address,address)", sender, owner));
+        vm.prank(sender);
+        SuccinctGateway(gateway).setWhitelistStatus(functionId, status);
+        assertTrue(SuccinctGateway(gateway).whitelistStatus(functionId) == WhitelistStatus.Default);
     }
 }
 

--- a/contracts/test/SuccinctGateway.t.sol
+++ b/contracts/test/SuccinctGateway.t.sol
@@ -6,29 +6,19 @@ import "forge-std/console.sol";
 import "forge-std/Test.sol";
 
 import {SuccinctGateway} from "src/SuccinctGateway.sol";
-import {
-    ISuccinctGateway,
-    ISuccinctGatewayEvents,
-    ISuccinctGatewayErrors
-} from "src/interfaces/ISuccinctGateway.sol";
-import {
-    TestConsumer,
-    AttackConsumer,
-    TestFunctionVerifier1,
-    TestFunctionVerifier2
-} from "test/TestUtils.sol";
-import {
-    IFunctionRegistry,
-    IFunctionRegistryEvents,
-    IFunctionRegistryErrors
-} from "src/interfaces/IFunctionRegistry.sol";
+import {ISuccinctGateway, ISuccinctGatewayEvents, ISuccinctGatewayErrors} from "src/interfaces/ISuccinctGateway.sol";
+import {TestConsumer, AttackConsumer, TestFunctionVerifier1, TestFunctionVerifier2} from "test/TestUtils.sol";
+import {IFunctionRegistry, IFunctionRegistryEvents, IFunctionRegistryErrors} from "src/interfaces/IFunctionRegistry.sol";
 import {TestConsumer, TestFunctionVerifier1} from "test/TestUtils.sol";
 import {Proxy} from "src/upgrades/Proxy.sol";
 import {SuccinctFeeVault} from "src/payments/SuccinctFeeVault.sol";
-import {AccessControlUpgradeable} from
-    "@openzeppelin-upgradeable/contracts/access/AccessControlUpgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin-upgradeable/contracts/access/AccessControlUpgradeable.sol";
 
-contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayErrors {
+contract SuccinctGatewayTest is
+    Test,
+    ISuccinctGatewayEvents,
+    ISuccinctGatewayErrors
+{
     // Example Function Request and expected values.
     bytes internal constant INPUT = bytes("function-input");
     bytes32 internal constant INPUT_HASH = sha256(INPUT);
@@ -73,12 +63,17 @@ contract SuccinctGatewayTest is Test, ISuccinctGatewayEvents, ISuccinctGatewayEr
         // Deploy Verifier
         bytes32 functionId;
         vm.prank(sender);
-        (functionId, verifier) = IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "test-verifier"
-        );
+        (functionId, verifier) = IFunctionRegistry(gateway)
+            .deployAndRegisterFunction(
+                owner,
+                type(TestFunctionVerifier1).creationCode,
+                "test-verifier"
+            );
 
         // Deploy TestConsumer
-        consumer = payable(address(new TestConsumer(gateway, functionId, INPUT)));
+        consumer = payable(
+            address(new TestConsumer(gateway, functionId, INPUT))
+        );
 
         vm.deal(sender, DEFAULT_FEE);
         vm.deal(consumer, DEFAULT_FEE);
@@ -90,9 +85,22 @@ contract SetupTest is SuccinctGatewayTest {
         bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
         assertEq(IFunctionRegistry(gateway).verifiers(functionId), verifier);
         assertEq(IFunctionRegistry(gateway).verifierOwners(functionId), owner);
-        assertEq(SuccinctGateway(gateway).allowedProvers(prover), true);
-        assertTrue(AccessControlUpgradeable(gateway).hasRole(keccak256("TIMELOCK_ROLE"), timelock));
-        assertTrue(AccessControlUpgradeable(gateway).hasRole(keccak256("GUARDIAN_ROLE"), guardian));
+        assertEq(
+            SuccinctGateway(gateway).allowedProvers(bytes32(0), prover),
+            true
+        );
+        assertTrue(
+            AccessControlUpgradeable(gateway).hasRole(
+                keccak256("TIMELOCK_ROLE"),
+                timelock
+            )
+        );
+        assertTrue(
+            AccessControlUpgradeable(gateway).hasRole(
+                keccak256("GUARDIAN_ROLE"),
+                guardian
+            )
+        );
     }
 }
 
@@ -317,13 +325,23 @@ contract RequestTest is SuccinctGatewayTest {
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
+        bytes memory callData = abi.encodeWithSelector(
+            TestConsumer.handleCall.selector
+        );
         uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
         uint256 fee = DEFAULT_FEE;
 
         // Request
         vm.expectEmit(true, true, true, true, gateway);
-        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
+        emit RequestCall(
+            functionId,
+            input,
+            callAddress,
+            callData,
+            callGasLimit,
+            consumer,
+            fee
+        );
         TestConsumer(consumer).requestCall{value: fee}();
 
         assertEq(TestConsumer(consumer).handledRequests(0), false);
@@ -333,7 +351,12 @@ contract RequestTest is SuccinctGatewayTest {
         emit Call(functionId, INPUT_HASH, OUTPUT_HASH);
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId, input, output, proof, callAddress, callData
+            functionId,
+            input,
+            output,
+            proof,
+            callAddress,
+            callData
         );
 
         assertEq(TestConsumer(consumer).handledRequests(0), true);
@@ -345,12 +368,19 @@ contract RequestTest is SuccinctGatewayTest {
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
+        bytes memory callData = abi.encodeWithSelector(
+            TestConsumer.handleCall.selector
+        );
 
         // Fulfill
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId, input, output, proof, callAddress, callData
+            functionId,
+            input,
+            output,
+            proof,
+            callAddress,
+            callData
         );
     }
 
@@ -360,13 +390,23 @@ contract RequestTest is SuccinctGatewayTest {
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
+        bytes memory callData = abi.encodeWithSelector(
+            TestConsumer.handleCall.selector
+        );
         uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
         uint256 fee = 0;
 
         // Request
         vm.expectEmit(true, true, true, true, gateway);
-        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
+        emit RequestCall(
+            functionId,
+            input,
+            callAddress,
+            callData,
+            callGasLimit,
+            consumer,
+            fee
+        );
         TestConsumer(consumer).requestCall{value: fee}();
 
         assertEq(TestConsumer(consumer).handledRequests(0), false);
@@ -376,7 +416,12 @@ contract RequestTest is SuccinctGatewayTest {
         emit Call(functionId, INPUT_HASH, OUTPUT_HASH);
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId, input, output, proof, callAddress, callData
+            functionId,
+            input,
+            output,
+            proof,
+            callAddress,
+            callData
         );
 
         assertEq(TestConsumer(consumer).handledRequests(0), true);
@@ -391,13 +436,23 @@ contract RequestTest is SuccinctGatewayTest {
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
+        bytes memory callData = abi.encodeWithSelector(
+            TestConsumer.handleCall.selector
+        );
         uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
         uint256 fee = DEFAULT_FEE;
 
         // Request
         vm.expectEmit(true, true, true, true, gateway);
-        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
+        emit RequestCall(
+            functionId,
+            input,
+            callAddress,
+            callData,
+            callGasLimit,
+            consumer,
+            fee
+        );
         TestConsumer(consumer).requestCall{value: fee}();
 
         assertEq(TestConsumer(consumer).handledRequests(0), false);
@@ -407,7 +462,12 @@ contract RequestTest is SuccinctGatewayTest {
         emit Call(functionId, INPUT_HASH, OUTPUT_HASH);
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId, input, output, proof, callAddress, callData
+            functionId,
+            input,
+            output,
+            proof,
+            callAddress,
+            callData
         );
 
         assertEq(TestConsumer(consumer).handledRequests(0), true);
@@ -419,7 +479,9 @@ contract RequestTest is SuccinctGatewayTest {
         bytes memory output = OUTPUT;
         bytes memory proof = PROOF;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
+        bytes memory callData = abi.encodeWithSelector(
+            TestConsumer.handleCall.selector
+        );
         uint256 fee = DEFAULT_FEE;
 
         // Request
@@ -429,7 +491,12 @@ contract RequestTest is SuccinctGatewayTest {
         vm.expectRevert(abi.encodeWithSelector(OnlyProver.selector, sender));
         vm.prank(sender);
         SuccinctGateway(gateway).fulfillCall(
-            functionId, input, output, proof, callAddress, callData
+            functionId,
+            input,
+            output,
+            proof,
+            callAddress,
+            callData
         );
     }
 
@@ -453,7 +520,9 @@ contract RequestTest is SuccinctGatewayTest {
         bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
 
         // Verify call
-        vm.expectRevert(abi.encodeWithSelector(InvalidCall.selector, functionId, input));
+        vm.expectRevert(
+            abi.encodeWithSelector(InvalidCall.selector, functionId, input)
+        );
         TestConsumer(consumer).verifiedCall();
     }
 }
@@ -467,12 +536,17 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         // Deploy Verifier
         bytes32 functionId;
         vm.prank(sender);
-        (functionId, verifier) = IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "attack-verifier"
-        );
+        (functionId, verifier) = IFunctionRegistry(gateway)
+            .deployAndRegisterFunction(
+                owner,
+                type(TestFunctionVerifier1).creationCode,
+                "attack-verifier"
+            );
 
         // Deploy AttackConsumer
-        attackConsumer = payable(address(new AttackConsumer(gateway, functionId, INPUT)));
+        attackConsumer = payable(
+            address(new AttackConsumer(gateway, functionId, INPUT))
+        );
 
         vm.deal(attackConsumer, DEFAULT_FEE);
     }
@@ -483,13 +557,18 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         bytes32 functionId = AttackConsumer(attackConsumer).FUNCTION_ID();
         bytes32 inputHash = INPUT_HASH;
         address callbackAddress = attackConsumer;
-        bytes4 callbackSelector = AttackConsumer.handleCallbackReenterCallback.selector;
-        uint32 callbackGasLimit = AttackConsumer(attackConsumer).CALLBACK_GAS_LIMIT();
+        bytes4 callbackSelector = AttackConsumer
+            .handleCallbackReenterCallback
+            .selector;
+        uint32 callbackGasLimit = AttackConsumer(attackConsumer)
+            .CALLBACK_GAS_LIMIT();
         uint256 fee = DEFAULT_FEE;
 
         // Request
         vm.prank(sender);
-        AttackConsumer(attackConsumer).requestCallbackReenterCallback{value: fee}();
+        AttackConsumer(attackConsumer).requestCallbackReenterCallback{
+            value: fee
+        }();
 
         // Fulfill (test fails this doesn't revert with ReentrantFulfill() error)
         vm.prank(prover);
@@ -512,8 +591,11 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         bytes32 functionId = AttackConsumer(attackConsumer).FUNCTION_ID();
         bytes32 inputHash = INPUT_HASH;
         address callbackAddress = attackConsumer;
-        bytes4 callbackSelector = AttackConsumer.handleCallbackReenterCall.selector;
-        uint32 callbackGasLimit = AttackConsumer(attackConsumer).CALLBACK_GAS_LIMIT();
+        bytes4 callbackSelector = AttackConsumer
+            .handleCallbackReenterCall
+            .selector;
+        uint32 callbackGasLimit = AttackConsumer(attackConsumer)
+            .CALLBACK_GAS_LIMIT();
         uint256 fee = DEFAULT_FEE;
 
         // Request
@@ -541,8 +623,9 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         bytes memory proof = PROOF;
         bytes32 functionId = AttackConsumer(attackConsumer).FUNCTION_ID();
         address callAddress = attackConsumer;
-        bytes memory callData =
-            abi.encodeWithSelector(AttackConsumer.handleCallReenterCallback.selector);
+        bytes memory callData = abi.encodeWithSelector(
+            AttackConsumer.handleCallReenterCallback.selector
+        );
         uint256 fee = DEFAULT_FEE;
 
         // Request
@@ -552,7 +635,12 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         // Fulfill (test fails this doesn't revert with ReentrantFulfill() error)
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId, input, output, proof, callAddress, callData
+            functionId,
+            input,
+            output,
+            proof,
+            callAddress,
+            callData
         );
     }
 
@@ -562,8 +650,9 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         bytes memory proof = PROOF;
         bytes32 functionId = AttackConsumer(attackConsumer).FUNCTION_ID();
         address callAddress = attackConsumer;
-        bytes memory callData =
-            abi.encodeWithSelector(AttackConsumer.handleCallReenterCall.selector);
+        bytes memory callData = abi.encodeWithSelector(
+            AttackConsumer.handleCallReenterCall.selector
+        );
         uint256 fee = DEFAULT_FEE;
 
         // Request
@@ -573,7 +662,12 @@ contract AttackSuccinctGatewayTest is SuccinctGatewayTest {
         // Fulfill (test fails this doesn't revert with ReentrantFulfill() error)
         vm.prank(prover);
         SuccinctGateway(gateway).fulfillCall(
-            functionId, input, output, proof, callAddress, callData
+            functionId,
+            input,
+            output,
+            proof,
+            callAddress,
+            callData
         );
     }
 }
@@ -584,8 +678,10 @@ contract FunctionRegistryTest is
     IFunctionRegistryErrors
 {
     function test_RegisterFunction() public {
-        bytes32 expectedFunctionId1 =
-            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
+        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
+            owner,
+            "test-verifier1"
+        );
 
         // Deploy verifier
         address verifier1;
@@ -597,18 +693,34 @@ contract FunctionRegistryTest is
 
         // Register function
         vm.expectEmit(true, true, true, true, gateway);
-        emit FunctionRegistered(expectedFunctionId1, verifier1, "test-verifier1", owner);
-        bytes32 functionId1 =
-            IFunctionRegistry(gateway).registerFunction(owner, verifier1, "test-verifier1");
+        emit FunctionRegistered(
+            expectedFunctionId1,
+            verifier1,
+            "test-verifier1",
+            owner
+        );
+        bytes32 functionId1 = IFunctionRegistry(gateway).registerFunction(
+            owner,
+            verifier1,
+            "test-verifier1"
+        );
 
         assertEq(functionId1, expectedFunctionId1);
-        assertEq(IFunctionRegistry(gateway).verifiers(expectedFunctionId1), verifier1);
-        assertEq(IFunctionRegistry(gateway).verifierOwners(expectedFunctionId1), owner);
+        assertEq(
+            IFunctionRegistry(gateway).verifiers(expectedFunctionId1),
+            verifier1
+        );
+        assertEq(
+            IFunctionRegistry(gateway).verifierOwners(expectedFunctionId1),
+            owner
+        );
     }
 
     function test_RegisterFunction_WhenOwnerIsSender() public {
-        bytes32 expectedFunctionId1 =
-            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
+        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
+            owner,
+            "test-verifier1"
+        );
 
         // Deploy verifier
         address verifier1;
@@ -620,21 +732,38 @@ contract FunctionRegistryTest is
 
         // Register function
         vm.expectEmit(true, true, true, true, gateway);
-        emit FunctionRegistered(expectedFunctionId1, verifier1, "test-verifier1", owner);
+        emit FunctionRegistered(
+            expectedFunctionId1,
+            verifier1,
+            "test-verifier1",
+            owner
+        );
         vm.prank(owner);
-        bytes32 functionId1 =
-            IFunctionRegistry(gateway).registerFunction(owner, verifier1, "test-verifier1");
+        bytes32 functionId1 = IFunctionRegistry(gateway).registerFunction(
+            owner,
+            verifier1,
+            "test-verifier1"
+        );
 
         assertEq(functionId1, expectedFunctionId1);
-        assertEq(IFunctionRegistry(gateway).verifiers(expectedFunctionId1), verifier1);
-        assertEq(IFunctionRegistry(gateway).verifierOwners(expectedFunctionId1), owner);
+        assertEq(
+            IFunctionRegistry(gateway).verifiers(expectedFunctionId1),
+            verifier1
+        );
+        assertEq(
+            IFunctionRegistry(gateway).verifierOwners(expectedFunctionId1),
+            owner
+        );
     }
 
     function test_RevertRegisterFunction_WhenAlreadyRegistered() public {
         // Deploy verifier
         address verifier1;
         bytes memory bytecode = type(TestFunctionVerifier1).creationCode;
-        bytes32 salt = IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
+        bytes32 salt = IFunctionRegistry(gateway).getFunctionId(
+            owner,
+            "test-verifier1"
+        );
         assembly {
             verifier1 := create2(0, add(bytecode, 32), mload(bytecode), salt)
         }
@@ -642,28 +771,49 @@ contract FunctionRegistryTest is
         // Register function
         vm.expectEmit(true, true, true, true, gateway);
         emit FunctionRegistered(salt, verifier1, "test-verifier1", owner);
-        IFunctionRegistry(gateway).registerFunction(owner, verifier1, "test-verifier1");
+        IFunctionRegistry(gateway).registerFunction(
+            owner,
+            verifier1,
+            "test-verifier1"
+        );
 
         // Register function again
-        vm.expectRevert(abi.encodeWithSelector(FunctionAlreadyRegistered.selector, salt));
-        IFunctionRegistry(gateway).registerFunction(owner, verifier1, "test-verifier1");
+        vm.expectRevert(
+            abi.encodeWithSelector(FunctionAlreadyRegistered.selector, salt)
+        );
+        IFunctionRegistry(gateway).registerFunction(
+            owner,
+            verifier1,
+            "test-verifier1"
+        );
     }
 
     function test_DeployAndRegisterFunction() public {
-        bytes32 expectedFunctionId1 =
-            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
+        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
+            owner,
+            "test-verifier1"
+        );
 
         // Deploy verifier and register function
         vm.expectEmit(true, false, false, true, gateway);
         emit Deployed(
-            keccak256(type(TestFunctionVerifier1).creationCode), expectedFunctionId1, address(0)
+            keccak256(type(TestFunctionVerifier1).creationCode),
+            expectedFunctionId1,
+            address(0)
         );
         vm.expectEmit(true, true, true, false, gateway);
-        emit FunctionRegistered(expectedFunctionId1, address(0), "test-verifier1", owner);
+        emit FunctionRegistered(
+            expectedFunctionId1,
+            address(0),
+            "test-verifier1",
+            owner
+        );
         (bytes32 functionId1, address verifier1) = IFunctionRegistry(gateway)
             .deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
-        );
+                owner,
+                type(TestFunctionVerifier1).creationCode,
+                "test-verifier1"
+            );
 
         assertEq(functionId1, expectedFunctionId1);
         assertEq(IFunctionRegistry(gateway).verifiers(functionId1), verifier1);
@@ -671,47 +821,74 @@ contract FunctionRegistryTest is
     }
 
     function test_DeployAndRegisterFunction_WhenOwnerIsSender() public {
-        bytes32 expectedFunctionId1 =
-            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
+        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
+            owner,
+            "test-verifier1"
+        );
 
         // Deploy verifier and register function
         vm.expectEmit(true, false, false, true, gateway);
         emit Deployed(
-            keccak256(type(TestFunctionVerifier1).creationCode), expectedFunctionId1, address(0)
+            keccak256(type(TestFunctionVerifier1).creationCode),
+            expectedFunctionId1,
+            address(0)
         );
         vm.expectEmit(true, true, true, false, gateway);
-        emit FunctionRegistered(expectedFunctionId1, address(0), "test-verifier1", owner);
+        emit FunctionRegistered(
+            expectedFunctionId1,
+            address(0),
+            "test-verifier1",
+            owner
+        );
         vm.prank(owner);
         (bytes32 functionId1, address verifier1) = IFunctionRegistry(gateway)
             .deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
-        );
+                owner,
+                type(TestFunctionVerifier1).creationCode,
+                "test-verifier1"
+            );
 
         assertEq(functionId1, expectedFunctionId1);
         assertEq(IFunctionRegistry(gateway).verifiers(functionId1), verifier1);
         assertEq(IFunctionRegistry(gateway).verifierOwners(functionId1), owner);
     }
 
-    function test_RevertDeployAndRegisterFunction_WhenAlreadyRegistered() public {
+    function test_RevertDeployAndRegisterFunction_WhenAlreadyRegistered()
+        public
+    {
         // Deploy verifier and register function
-        (bytes32 functionId1,) = IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
-        );
+        (bytes32 functionId1, ) = IFunctionRegistry(gateway)
+            .deployAndRegisterFunction(
+                owner,
+                type(TestFunctionVerifier1).creationCode,
+                "test-verifier1"
+            );
 
         // Deploy verifier and register function again
-        vm.expectRevert(abi.encodeWithSelector(FunctionAlreadyRegistered.selector, functionId1));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FunctionAlreadyRegistered.selector,
+                functionId1
+            )
+        );
         IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
+            owner,
+            type(TestFunctionVerifier1).creationCode,
+            "test-verifier1"
         );
     }
 
     function test_UpdateFunction() public {
-        bytes32 expectedFunctionId1 =
-            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
+        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
+            owner,
+            "test-verifier1"
+        );
 
         // Deploy verifier and register function
         IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
+            owner,
+            type(TestFunctionVerifier1).creationCode,
+            "test-verifier1"
         );
 
         // Deploy verifier
@@ -726,7 +903,10 @@ contract FunctionRegistryTest is
         vm.expectEmit(true, true, true, true, gateway);
         emit FunctionVerifierUpdated(expectedFunctionId1, verifier2);
         vm.prank(owner);
-        bytes32 functionId1 = IFunctionRegistry(gateway).updateFunction(verifier2, "test-verifier1");
+        bytes32 functionId1 = IFunctionRegistry(gateway).updateFunction(
+            verifier2,
+            "test-verifier1"
+        );
 
         assertEq(functionId1, expectedFunctionId1);
         assertEq(IFunctionRegistry(gateway).verifiers(functionId1), verifier2);
@@ -735,9 +915,12 @@ contract FunctionRegistryTest is
 
     function test_RevertUpdateFunction_WhenNotOwner() public {
         // Deploy verifier and register function
-        (bytes32 functionId,) = IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
-        );
+        (bytes32 functionId, ) = IFunctionRegistry(gateway)
+            .deployAndRegisterFunction(
+                owner,
+                type(TestFunctionVerifier1).creationCode,
+                "test-verifier1"
+            );
 
         // Deploy verifier
         address verifier2;
@@ -749,7 +932,13 @@ contract FunctionRegistryTest is
 
         // Update function
         vm.prank(sender);
-        vm.expectRevert(abi.encodeWithSelector(NotFunctionOwner.selector, sender, address(0)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                NotFunctionOwner.selector,
+                sender,
+                address(0)
+            )
+        );
         IFunctionRegistry(gateway).updateFunction(verifier2, "test-verifier1");
     }
 
@@ -763,7 +952,9 @@ contract FunctionRegistryTest is
         }
 
         // Update function
-        vm.expectRevert(abi.encodeWithSelector(NotFunctionOwner.selector, owner, address(0)));
+        vm.expectRevert(
+            abi.encodeWithSelector(NotFunctionOwner.selector, owner, address(0))
+        );
         vm.prank(owner);
         IFunctionRegistry(gateway).updateFunction(verifier2, "test-verifier1");
     }
@@ -772,34 +963,47 @@ contract FunctionRegistryTest is
         // Deploy verifier and register function
         (bytes32 functionId1, address verifier1) = IFunctionRegistry(gateway)
             .deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
-        );
+                owner,
+                type(TestFunctionVerifier1).creationCode,
+                "test-verifier1"
+            );
 
         // Update function
-        vm.expectRevert(abi.encodeWithSelector(VerifierAlreadyUpdated.selector, functionId1));
+        vm.expectRevert(
+            abi.encodeWithSelector(VerifierAlreadyUpdated.selector, functionId1)
+        );
         vm.prank(owner);
         IFunctionRegistry(gateway).updateFunction(verifier1, "test-verifier1");
     }
 
     function test_deployAndUpdateFunction() public {
-        bytes32 expectedFunctionId1 =
-            IFunctionRegistry(gateway).getFunctionId(owner, "test-verifier1");
+        bytes32 expectedFunctionId1 = IFunctionRegistry(gateway).getFunctionId(
+            owner,
+            "test-verifier1"
+        );
 
         // Deploy verifier and register function
         IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
+            owner,
+            type(TestFunctionVerifier1).creationCode,
+            "test-verifier1"
         );
 
         // Deploy verifier and update function
         vm.expectEmit(true, false, false, true, gateway);
         emit Deployed(
-            keccak256(type(TestFunctionVerifier2).creationCode), expectedFunctionId1, address(0)
+            keccak256(type(TestFunctionVerifier2).creationCode),
+            expectedFunctionId1,
+            address(0)
         );
         vm.expectEmit(true, true, true, false, gateway);
         emit FunctionVerifierUpdated(expectedFunctionId1, address(0));
         vm.prank(owner);
         (bytes32 functionId1, address verifier2) = IFunctionRegistry(gateway)
-            .deployAndUpdateFunction(type(TestFunctionVerifier2).creationCode, "test-verifier1");
+            .deployAndUpdateFunction(
+                type(TestFunctionVerifier2).creationCode,
+                "test-verifier1"
+            );
 
         assertEq(functionId1, expectedFunctionId1);
         assertEq(IFunctionRegistry(gateway).verifiers(functionId1), verifier2);
@@ -809,37 +1013,52 @@ contract FunctionRegistryTest is
     function test_RevertDeployAndUpdateFunction_WhenNotOwner() public {
         // Deploy verifier and register function
         IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
+            owner,
+            type(TestFunctionVerifier1).creationCode,
+            "test-verifier1"
         );
 
         // Deploy verifier and update function
         vm.prank(sender);
-        vm.expectRevert(abi.encodeWithSelector(NotFunctionOwner.selector, sender, address(0)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                NotFunctionOwner.selector,
+                sender,
+                address(0)
+            )
+        );
         IFunctionRegistry(gateway).deployAndUpdateFunction(
-            type(TestFunctionVerifier2).creationCode, "test-verifier1"
+            type(TestFunctionVerifier2).creationCode,
+            "test-verifier1"
         );
     }
 
     function test_RevertDeployAndUpdateFunction_WhenNeverRegistered() public {
         // Deploy verifier and update function
-        vm.expectRevert(abi.encodeWithSelector(NotFunctionOwner.selector, owner, address(0)));
+        vm.expectRevert(
+            abi.encodeWithSelector(NotFunctionOwner.selector, owner, address(0))
+        );
         vm.prank(owner);
         IFunctionRegistry(gateway).deployAndUpdateFunction(
-            type(TestFunctionVerifier1).creationCode, "test-verifier1"
+            type(TestFunctionVerifier1).creationCode,
+            "test-verifier1"
         );
     }
 
     function test_RevertDeployAndUpdateFunction_WhenBytecodeSame() public {
         // Deploy verifier and register function
         IFunctionRegistry(gateway).deployAndRegisterFunction(
-            owner, type(TestFunctionVerifier1).creationCode, "test-verifier1"
+            owner,
+            type(TestFunctionVerifier1).creationCode,
+            "test-verifier1"
         );
 
         // Deploy verifier and update function
         vm.expectRevert(abi.encodeWithSelector(FailedDeploy.selector));
         vm.prank(owner);
         IFunctionRegistry(gateway).deployAndUpdateFunction(
-            type(TestFunctionVerifier1).creationCode, "test-verifier1"
+            type(TestFunctionVerifier1).creationCode,
+            "test-verifier1"
         );
     }
 }
@@ -850,29 +1069,45 @@ contract UpdateProverTest is SuccinctGatewayTest {
 
         vm.prank(guardian);
         SuccinctGateway(gateway).addProver(newProver);
-        assertEq(SuccinctGateway(gateway).allowedProvers(newProver), true);
+        assertEq(
+            SuccinctGateway(gateway).allowedProvers(bytes32(0), newProver),
+            true
+        );
     }
 
     function test_RevertAddProver_WhenNotGuardian() public {
         address newProver = makeAddr("new-prover");
 
-        vm.expectRevert(abi.encodeWithSignature("OnlyGuardian(address)", sender));
+        vm.expectRevert(
+            abi.encodeWithSignature("OnlyGuardian(address)", sender)
+        );
         vm.prank(sender);
         SuccinctGateway(gateway).addProver(newProver);
-        assertEq(SuccinctGateway(gateway).allowedProvers(newProver), false);
+        assertEq(
+            SuccinctGateway(gateway).allowedProvers(bytes32(0), newProver),
+            false
+        );
     }
 
     function test_RemoveProver() public {
         vm.prank(guardian);
         SuccinctGateway(gateway).removeProver(prover);
-        assertEq(SuccinctGateway(gateway).allowedProvers(prover), false);
+        assertEq(
+            SuccinctGateway(gateway).allowedProvers(bytes32(0), prover),
+            false
+        );
     }
 
     function test_RevertRemoveProver_WhenNotGuardian() public {
-        vm.expectRevert(abi.encodeWithSignature("OnlyGuardian(address)", sender));
+        vm.expectRevert(
+            abi.encodeWithSignature("OnlyGuardian(address)", sender)
+        );
         vm.prank(sender);
         SuccinctGateway(gateway).removeProver(prover);
-        assertEq(SuccinctGateway(gateway).allowedProvers(prover), true);
+        assertEq(
+            SuccinctGateway(gateway).allowedProvers(bytes32(0), prover),
+            true
+        );
     }
 }
 
@@ -881,7 +1116,9 @@ contract SetFeeVaultTest is SuccinctGatewayTest {
         bytes32 functionId = TestConsumer(consumer).FUNCTION_ID();
         bytes memory input = INPUT;
         address callAddress = consumer;
-        bytes memory callData = abi.encodeWithSelector(TestConsumer.handleCall.selector);
+        bytes memory callData = abi.encodeWithSelector(
+            TestConsumer.handleCall.selector
+        );
         uint32 callGasLimit = TestConsumer(consumer).CALLBACK_GAS_LIMIT();
         uint256 fee = DEFAULT_FEE;
         address newFeeVault = address(new SuccinctFeeVault());
@@ -896,7 +1133,15 @@ contract SetFeeVaultTest is SuccinctGatewayTest {
 
         // Request with fee
         vm.expectEmit(true, true, true, true, gateway);
-        emit RequestCall(functionId, input, callAddress, callData, callGasLimit, consumer, fee);
+        emit RequestCall(
+            functionId,
+            input,
+            callAddress,
+            callData,
+            callGasLimit,
+            consumer,
+            fee
+        );
         TestConsumer(consumer).requestCall{value: fee}();
     }
 


### PR DESCRIPTION
Function owners can now specify if they want to use the default prover, a custom prover that they specify, or disable whitelisted proving altogether.

Audit Issue: https://veridise.notion.site/Contracts-Centralization-Risk-ec97d40516f3487eb907f2bd01f6135c Different from the recommended solution, but this solution was also with keeping in mind with some feedback from users.