### PR TITLE
feat: recover funds from SuccinctGateway

### DIFF
--- a/contracts/src/SuccinctGateway.sol
+++ b/contracts/src/SuccinctGateway.sol
@@ -314,7 +314,7 @@ contract SuccinctGateway is ISuccinctGateway, FunctionRegistry, TimelockedUpgrad
         if (msg.sender != verifierOwners[_functionId]) {
             revert NotFunctionOwner(msg.sender, verifierOwners[_functionId]);
         }
-        allowedProvers[_functionId][_prover] = false;
+        delete allowedProvers[_functionId][_prover];
         emit ProverUpdated(_functionId, _prover, false);
     }
 
@@ -328,7 +328,7 @@ contract SuccinctGateway is ISuccinctGateway, FunctionRegistry, TimelockedUpgrad
     /// @notice Remove a default prover.
     /// @param _prover The address of the prover to remove.
     function removeDefaultProver(address _prover) external onlyGuardian {
-        allowedProvers[bytes32(0)][_prover] = false;
+        delete allowedProvers[bytes32(0)][_prover];
         emit ProverUpdated(bytes32(0), _prover, false);
     }
 
@@ -337,6 +337,16 @@ contract SuccinctGateway is ISuccinctGateway, FunctionRegistry, TimelockedUpgrad
     function setFeeVault(address _feeVault) external onlyGuardian {
         emit SetFeeVault(feeVault, _feeVault);
         feeVault = _feeVault;
+    }
+
+    /// @notice Recovers stuck ETH from the contract.
+    /// @param _to The address to send the ETH to.
+    /// @param _amount The wei amount of ETH to send.
+    function recover(address _to, uint256 _amount) external onlyGuardian {
+        (bool success,) = _to.call{value: _amount}("");
+        if (!success) {
+            revert RecoverFailed();
+        }
     }
 
     /// @dev Computes a unique identifier for a request.

--- a/contracts/src/interfaces/ISuccinctGateway.sol
+++ b/contracts/src/interfaces/ISuccinctGateway.sol
@@ -44,6 +44,7 @@ interface ISuccinctGatewayErrors {
     error InvalidProof(address verifier, bytes32 inputHash, bytes32 outputHash, bytes proof);
     error ReentrantFulfill();
     error OnlyProver(bytes32 functionId, address sender);
+    error RecoverFailed();
 }
 
 interface ISuccinctGateway is ISuccinctGatewayEvents, ISuccinctGatewayErrors {


### PR DESCRIPTION
Because the `request*()` functions accept fees even when the feeVault is not set:
```solidity
        if (feeVault != address(0)) {
            IFeeVault(feeVault).depositNative{value: msg.value}(callbackAddress);
        }
```
it is possible for the contract to have some stuck funds in the SuccinctGateway. This change allows the guardian to recover the funds.

Audit Issue: https://veridise.notion.site/Contracts-funds-may-be-locked-when-feeVault-is-disabled-5c75f079cead42d696143c4bf234bcfc

---

Also adds:

delete instead of setting to zero reduces gas costs for removeProver.

Audit Issue: https://veridise.notion.site/Contracts-Possible-Wasted-Gas-3860531b4bc4471d91fe21117a8a281a (other suggestions are being addressed in other PRs)