### PR TITLE
refactor(audit): sha256 variable

### DIFF
--- a/plonky2x/core/src/frontend/hash/sha/sha256/curta.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha256/curta.rs
@@ -143,11 +143,15 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         input: &[ByteVariable],
         length: U32Variable,
     ) -> Bytes32Variable {
-        assert_eq!(
-            input.len() % 64,
-            0,
-            "input length should be a multiple of 64"
-        );
+        // Extend input's length to the nearest multiple of 64 (if it is not already).
+        let mut input = input.to_vec();
+        if (input.len() % 64) != 0 {
+            input.resize(
+                input.len() + 64 - (input.len() % 64),
+                self.constant::<ByteVariable>(0),
+            );
+        }
+
         let last_chunk = self.compute_sha256_last_chunk(length);
         if self.sha256_accelerator.is_none() {
             self.sha256_accelerator = Some(SHA256Accelerator {


### PR DESCRIPTION
Remove unnecessary check on the size of input to `sha256_variable`. Extend inputs that to a multiple of 64 bytes if they are not already.