### PR TITLE
chore: make `poseidon_bn128` constants public

### DIFF
--- a/plonky2x/core/src/backend/wrapper/mod.rs
+++ b/plonky2x/core/src/backend/wrapper/mod.rs
@@ -1,5 +1,5 @@
 pub mod plonky2_config;
 pub mod poseidon_bn128;
-mod poseidon_bn128_constants;
+pub mod poseidon_bn128_constants;
 pub mod utils;
 pub mod wrap;

--- a/plonky2x/core/src/backend/wrapper/plonky2_config.rs
+++ b/plonky2x/core/src/backend/wrapper/plonky2_config.rs
@@ -28,7 +28,7 @@ impl GenericConfig<2> for PoseidonBN128GoldilocksConfig {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct PoseidonBN128HashOut<F: Field> {
-    value: Fr,
+    pub value: Fr,
     _phantom: PhantomData<F>,
 }
 

--- a/plonky2x/core/src/backend/wrapper/poseidon_bn128.rs
+++ b/plonky2x/core/src/backend/wrapper/poseidon_bn128.rs
@@ -9,8 +9,8 @@ use crate::backend::wrapper::utils::Fr;
 
 pub const RATE: usize = 3;
 pub const WIDTH: usize = 4;
-const FULL_ROUNDS: usize = 8;
-const PARTIAL_ROUNDS: usize = 56;
+pub const FULL_ROUNDS: usize = 8;
+pub const PARTIAL_ROUNDS: usize = 56;
 pub const GOLDILOCKS_ELEMENTS: usize = 3;
 
 pub type PoseidonState = [Fr; WIDTH];


### PR DESCRIPTION
I've been using the PoseidonBN128 hash with plonky2 to do some benchmarking [here](https://github.com/shuklaayush/halo2-plonky2-verifier). Would be great if I could directly use the constants from the repo instead of redefining them