### PR TITLE
feat(succinct-client): local relaying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3982,10 +3982,12 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "ethers",
  "log",
  "reqwest",
  "serde",
  "serde_json",
+ "toml",
  "uuid 1.6.1",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3984,6 +3984,7 @@ dependencies = [
  "anyhow",
  "ethers",
  "log",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 [dependencies]
 alloy-primitives = { version = "0.4.2", features = ["serde"] }
 anyhow = "1.0.75"
+ethers = "2.0.11"
 log = "0.4.20"
 reqwest = { version = "0.11.22", features = ["json"] }
-serde = "1.0.192"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.108"
+toml = "0.8.8"
 uuid = { version = "1.6.1", features = ["serde", "v4"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,6 +8,7 @@ alloy-primitives = { version = "0.4.2", features = ["serde"] }
 anyhow = "1.0.75"
 ethers = "2.0.11"
 log = "0.4.20"
+regex = "1.10.2"
 reqwest = { version = "0.11.22", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.108"

--- a/client/abi/SuccinctGateway.abi.json
+++ b/client/abi/SuccinctGateway.abi.json
@@ -1,0 +1,1485 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "callbackAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "callbackData",
+                "type": "bytes"
+            }
+        ],
+        "name": "CallFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "callbackSelector",
+                "type": "bytes4"
+            },
+            {
+                "internalType": "bytes",
+                "name": "output",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "context",
+                "type": "bytes"
+            }
+        ],
+        "name": "CallbackFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "EmptyBytecode",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "FailedDeploy",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "FunctionAlreadyRegistered",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes",
+                "name": "input",
+                "type": "bytes"
+            }
+        ],
+        "name": "InvalidCall",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "verifier",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "inputHash",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "outputHash",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes",
+                "name": "proof",
+                "type": "bytes"
+            }
+        ],
+        "name": "InvalidProof",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint32",
+                "name": "nonce",
+                "type": "uint32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "expectedRequestHash",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "requestHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "InvalidRequest",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "actualOwner",
+                "type": "address"
+            }
+        ],
+        "name": "NotFunctionOwner",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "OnlyGuardian",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "OnlyProver",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "OnlyTimelock",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "RecoverFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ReentrantFulfill",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "VerifierAlreadyUpdated",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "VerifierCannotBeZero",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "previousAdmin",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "newAdmin",
+                "type": "address"
+            }
+        ],
+        "name": "AdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "beacon",
+                "type": "address"
+            }
+        ],
+        "name": "BeaconUpgraded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "inputHash",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "outputHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "Call",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "bytecodeHash",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "salt",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "deployedAddress",
+                "type": "address"
+            }
+        ],
+        "name": "Deployed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "verifier",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "salt",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            }
+        ],
+        "name": "FunctionRegistered",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "verifier",
+                "type": "address"
+            }
+        ],
+        "name": "FunctionVerifierUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint8",
+                "name": "version",
+                "type": "uint8"
+            }
+        ],
+        "name": "Initialized",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "prover",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "added",
+                "type": "bool"
+            }
+        ],
+        "name": "ProverUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "input",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "entryAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "entryCalldata",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint32",
+                "name": "entryGasLimit",
+                "type": "uint32"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "feeAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RequestCall",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint32",
+                "name": "nonce",
+                "type": "uint32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "input",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "context",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "callbackAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes4",
+                "name": "callbackSelector",
+                "type": "bytes4"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint32",
+                "name": "callbackGasLimit",
+                "type": "uint32"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "feeAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RequestCallback",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint32",
+                "name": "nonce",
+                "type": "uint32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "inputHash",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "outputHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "RequestFulfilled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "previousAdminRole",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "newAdminRole",
+                "type": "bytes32"
+            }
+        ],
+        "name": "RoleAdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleGranted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleRevoked",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "oldFeeVault",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newFeeVault",
+                "type": "address"
+            }
+        ],
+        "name": "SetFeeVault",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "implementation",
+                "type": "address"
+            }
+        ],
+        "name": "Upgraded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "enum WhitelistStatus",
+                "name": "status",
+                "type": "uint8"
+            }
+        ],
+        "name": "WhitelistStatusUpdated",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "DEFAULT_ADMIN_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "GUARDIAN_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "TIMELOCK_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "VERSION",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "_prover",
+                "type": "address"
+            }
+        ],
+        "name": "addCustomProver",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_prover",
+                "type": "address"
+            }
+        ],
+        "name": "addDefaultProver",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "allowedProvers",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_owner",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_bytecode",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_salt",
+                "type": "bytes32"
+            }
+        ],
+        "name": "deployAndRegisterFunction",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "verifier",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "_bytecode",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_salt",
+                "type": "bytes32"
+            }
+        ],
+        "name": "deployAndUpdateFunction",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "verifier",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "feeVault",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_input",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_output",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_proof",
+                "type": "bytes"
+            },
+            {
+                "internalType": "address",
+                "name": "_callbackAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_callbackData",
+                "type": "bytes"
+            }
+        ],
+        "name": "fulfillCall",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint32",
+                "name": "_nonce",
+                "type": "uint32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_inputHash",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "_callbackAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes4",
+                "name": "_callbackSelector",
+                "type": "bytes4"
+            },
+            {
+                "internalType": "uint32",
+                "name": "_callbackGasLimit",
+                "type": "uint32"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_context",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_output",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_proof",
+                "type": "bytes"
+            }
+        ],
+        "name": "fulfillCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_owner",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_salt",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getFunctionId",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRoleAdmin",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "grantRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "hasRole",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_feeVault",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_timelock",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_guardian",
+                "type": "address"
+            }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "isCallback",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "nonce",
+        "outputs": [
+            {
+                "internalType": "uint32",
+                "name": "",
+                "type": "uint32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "proxiableUUID",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_to",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "recover",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_owner",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_verifier",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_salt",
+                "type": "bytes32"
+            }
+        ],
+        "name": "registerFunction",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "_prover",
+                "type": "address"
+            }
+        ],
+        "name": "removeCustomProver",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_prover",
+                "type": "address"
+            }
+        ],
+        "name": "removeDefaultProver",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "renounceRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_input",
+                "type": "bytes"
+            },
+            {
+                "internalType": "address",
+                "name": "_entryAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_entryCalldata",
+                "type": "bytes"
+            },
+            {
+                "internalType": "uint32",
+                "name": "_entryGasLimit",
+                "type": "uint32"
+            }
+        ],
+        "name": "requestCall",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_input",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_context",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes4",
+                "name": "_callbackSelector",
+                "type": "bytes4"
+            },
+            {
+                "internalType": "uint32",
+                "name": "_callbackGasLimit",
+                "type": "uint32"
+            }
+        ],
+        "name": "requestCallback",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint32",
+                "name": "",
+                "type": "uint32"
+            }
+        ],
+        "name": "requests",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "revokeRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_feeVault",
+                "type": "address"
+            }
+        ],
+        "name": "setFeeVault",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "enum WhitelistStatus",
+                "name": "_status",
+                "type": "uint8"
+            }
+        ],
+        "name": "setWhitelistStatus",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_verifier",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_salt",
+                "type": "bytes32"
+            }
+        ],
+        "name": "updateFunction",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "functionId",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newImplementation",
+                "type": "address"
+            }
+        ],
+        "name": "upgradeTo",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newImplementation",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "upgradeToAndCall",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_functionId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_input",
+                "type": "bytes"
+            }
+        ],
+        "name": "verifiedCall",
+        "outputs": [
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "verifiedFunctionId",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "verifiedInputHash",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "verifiedOutput",
+        "outputs": [
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "name": "verifierOwners",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "name": "verifiers",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "name": "whitelistStatus",
+        "outputs": [
+            {
+                "internalType": "enum WhitelistStatus",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod request;
+pub mod utils;

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -396,8 +396,8 @@ impl SuccinctClient {
             let relayer_address = client.address();
             info!("Relayer address: {}", relayer_address);
 
-            let nonce = contract.nonce().call().await?;
-            info!("Nonce: {}", nonce);
+            let version = contract.version().call().await?;
+            info!("Version: {}", version);
 
             // Submit the proof to the Succinct X API.
             let tx = contract

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -370,6 +370,7 @@ impl SuccinctClient {
             }
 
             let succinct_proof_data: SuccinctProofData = serde_json::from_value(proof_json)?;
+            let wallet = wallet.with_chain_id(succinct_proof_data.chain_id);
 
             let provider =
                 Provider::<Http>::try_from(ethereum_rpc_url).expect("could not connect to client");

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -377,10 +377,15 @@ impl SuccinctClient {
 
             let address = get_gateway_address(succinct_proof_data.chain_id);
             // If gateway_address is provided, use that instead of the canonical gateway address.
-            let gateway_address = gateway_address.or(address).expect(
+            let mut gateway_address = gateway_address.or(address).expect(
                 "Gateway address must be provided when relaying a proof in local mode
                 if the chain does not have a canonical gateway address.",
             );
+
+            // Strip the 0x prefix from the gateway address.
+            if gateway_address.starts_with("0x") {
+                gateway_address = gateway_address.strip_prefix("0x").unwrap();
+            }
 
             let gateway_address_bytes: [u8; 20] =
                 hex::decode(gateway_address).unwrap().try_into().unwrap();

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -75,27 +75,27 @@ pub struct SuccinctClient {
     /// API key for the Succinct X API.
     succinct_api_key: String,
     /// Local prove mode flag.
-    local_prove_mode: Option<bool>,
+    local_prove_mode: bool,
     /// Local relay mode flag.
-    local_relay_mode: Option<bool>,
+    local_relay_mode: bool,
 }
 
 impl SuccinctClient {
     pub fn new(
         succinct_api_url: String,
         succinct_api_key: String,
-        local_prove_mode: Option<bool>,
-        local_relay_mode: Option<bool>,
+        local_prove_mode: bool,
+        local_relay_mode: bool,
     ) -> Self {
-        if local_prove_mode == Some(true) {
+        if local_prove_mode == true {
             info!("Running SuccinctClient in local prover mode");
         }
-        if local_relay_mode == Some(true) {
+        if local_relay_mode == true {
             info!("Running SuccinctClient in local relay mode");
         }
         // TODO: For now, if local_relay_mode is true, local_prove_mode must also be true. Once
         // local_relay_mode fetches from the Succinct X API, this can be removed.
-        if local_relay_mode == Some(true) && local_prove_mode != Some(true) {
+        if local_relay_mode && !local_prove_mode {
             panic!("local_relay_mode must be true if local_prove_mode is true")
         }
 
@@ -316,7 +316,7 @@ impl SuccinctClient {
         function_id: B256,
         input: Bytes,
     ) -> Result<String> {
-        if Some(true) == self.local_prove_mode {
+        if self.local_prove_mode {
             return self.submit_local_request(
                 chain_id,
                 to,
@@ -342,7 +342,7 @@ impl SuccinctClient {
         gateway_address: Option<&str>,
     ) -> Result<()> {
         // If local mode, submit proof from local directory at proofs/output_{request_id}.json
-        if Some(true) == self.local_relay_mode {
+        if self.local_relay_mode {
             let ethereum_rpc_url = ethereum_rpc_url
                 .expect("Ethereum RPC URL must be provided when relaying a proof in local mode.");
             let wallet =
@@ -390,6 +390,9 @@ impl SuccinctClient {
                 )
                 .await?;
         }
+
+        info!("Proof relayed successfully!");
+
         Ok(())
     }
 }

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -343,6 +343,11 @@ impl SuccinctClient {
     ) -> Result<()> {
         // If local mode, submit proof from local directory at proofs/output_{request_id}.json
         if Some(true) == self.local_relay_mode {
+            let ethereum_rpc_url = ethereum_rpc_url
+                .expect("Ethereum RPC URL must be provided when relaying a proof in local mode.");
+            let wallet =
+                wallet.expect("Local wallet must be provided when relaying a proof in local mode.");
+
             // Check if the proof file exists.
             let proof_file = format!("{}/output_{}.json", LOCAL_PROOF_FOLDER, request_id);
             if !Path::new(&proof_file).exists() {
@@ -357,11 +362,6 @@ impl SuccinctClient {
             let proof_json: serde_json::Value = serde_json::from_str(&proof_data)?;
 
             let succinct_proof_data: SuccinctProofData = serde_json::from_value(proof_json)?;
-
-            let ethereum_rpc_url = ethereum_rpc_url
-                .expect("Ethereum RPC URL must be provided when relaying a proof in local mode.");
-            let wallet =
-                wallet.expect("Wallet must be provided when relaying a proof in local mode.");
 
             let provider =
                 Provider::<Http>::try_from(ethereum_rpc_url).expect("could not connect to client");

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -392,7 +392,7 @@ impl SuccinctClient {
             let contract = SuccinctGateway::new(H160::from(gateway_address_bytes), client);
 
             // Submit the proof to the Succinct X API.
-            contract
+            let tx = contract
                 .fulfill_call(
                     succinct_proof_data.function_id.0,
                     ethers::types::Bytes(succinct_proof_data.input.0),
@@ -402,10 +402,9 @@ impl SuccinctClient {
                     ethers::types::Bytes(succinct_proof_data.calldata.0),
                 )
                 .await?;
+
+            info!("Proof relayed successfully!");
         }
-
-        info!("Proof relayed successfully!");
-
         Ok(())
     }
 }

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -11,6 +11,7 @@ use ethers::providers::{Http, Provider};
 use ethers::signers::LocalWallet;
 use ethers::types::H160;
 use log::{error, info};
+use regex::Regex;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json as json_macro;
@@ -359,7 +360,14 @@ impl SuccinctClient {
 
             // If it exists, attempt to submit the proof.
             let proof_data = fs::read_to_string(proof_file)?;
-            let proof_json: serde_json::Value = serde_json::from_str(&proof_data)?;
+            let mut proof_json: serde_json::Value = serde_json::from_str(&proof_data)?;
+            // Strip alphanumeric characters from each of the proof_data fields.
+            for (_, value) in proof_json.as_object_mut().unwrap().iter_mut() {
+                if let serde_json::Value::String(s) = value {
+                    let re = Regex::new(r"[A-Za-z0-9]").unwrap();
+                    *value = serde_json::Value::String(re.replace_all(s, "").to_string());
+                }
+            }
 
             let succinct_proof_data: SuccinctProofData = serde_json::from_value(proof_json)?;
 

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -364,7 +364,7 @@ impl SuccinctClient {
             // Strip alphanumeric characters from each of the proof_data fields.
             for (_, value) in proof_json.as_object_mut().unwrap().iter_mut() {
                 if let serde_json::Value::String(s) = value {
-                    let re = Regex::new(r"[A-Za-z0-9]").unwrap();
+                    let re = Regex::new(r"[^a-zA-Z0-9 -]").unwrap();
                     *value = serde_json::Value::String(re.replace_all(s, "").to_string());
                 }
             }

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -232,12 +232,21 @@ impl SuccinctClient {
             .and_then(|d| d.get("proof"))
             .ok_or_else(|| Error::msg("Proof not found in output.json"))?
             .to_string();
+        // Strip the 0x prefix from the proof if it exists.
+        let proof = proof
+            .strip_prefix("0x")
+            .map_or(proof.clone(), |stripped| stripped.to_string());
+
         let proof = Bytes::from(hex::decode(proof)?);
         let output_value = proof_json
             .get("data")
             .and_then(|d| d.get("output"))
             .ok_or_else(|| Error::msg("Output not found in output.json"))?
             .to_string();
+        // Strip the 0x prefix from the output if it exists.
+        let output_value = output_value
+            .strip_prefix("0x")
+            .map_or(output_value.clone(), |stripped| stripped.to_string());
         let output_value = Bytes::from(hex::decode(output_value)?);
 
         // Save to proofs/output_{request_id}.json

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -396,6 +396,9 @@ impl SuccinctClient {
             let relayer_address = client.address();
             info!("Relayer address: {}", relayer_address);
 
+            let nonce = contract.nonce().call().await?;
+            info!("Nonce: {}", nonce);
+
             // Submit the proof to the Succinct X API.
             let tx = contract
                 .fulfill_call(

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -7,7 +7,7 @@ use alloy_primitives::{hex, Address, Bytes, B256};
 use anyhow::{Error, Result};
 use ethers::contract::abigen;
 use ethers::middleware::SignerMiddleware;
-use ethers::providers::{Http, Middleware, Provider};
+use ethers::providers::{Http, Provider};
 use ethers::signers::{LocalWallet, Signer};
 use ethers::types::{TransactionReceipt, H160};
 use log::{error, info};
@@ -88,10 +88,10 @@ impl SuccinctClient {
         local_prove_mode: bool,
         local_relay_mode: bool,
     ) -> Self {
-        if local_prove_mode == true {
+        if local_prove_mode {
             info!("Running SuccinctClient in local prover mode");
         }
-        if local_relay_mode == true {
+        if local_relay_mode {
             info!("Running SuccinctClient in local relay mode");
         }
         // TODO: For now, if local_relay_mode is true, local_prove_mode must also be true. Once

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -389,7 +389,12 @@ impl SuccinctClient {
 
             let gateway_address_bytes: [u8; 20] =
                 hex::decode(gateway_address).unwrap().try_into().unwrap();
-            let contract = SuccinctGateway::new(H160::from(gateway_address_bytes), client);
+            let contract = SuccinctGateway::new(H160::from(gateway_address_bytes), client.clone());
+
+            info!("Relaying proof to gateway address: {}", gateway_address);
+
+            let relayer_address = client.address();
+            info!("Relayer address: {}", relayer_address);
 
             // Submit the proof to the Succinct X API.
             let tx = contract

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -409,10 +409,11 @@ impl SuccinctClient {
                 .await?;
 
             if let Some(tx) = tx {
-                info!("Transaction Hash: {:?}", tx.transaction_hash);
+                info!(
+                    "Proof relayed successfully! Transaction Hash: {:?}",
+                    tx.transaction_hash
+                );
             }
-
-            info!("Proof relayed successfully!");
         }
         Ok(())
     }

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -401,7 +401,11 @@ impl SuccinctClient {
                     H160(succinct_proof_data.to.0 .0),
                     ethers::types::Bytes(succinct_proof_data.calldata.0),
                 )
+                .send()
+                .await?
                 .await?;
+
+            info!("Transaction Receipt: {:?}", tx);
 
             info!("Proof relayed successfully!");
         }

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -344,7 +344,7 @@ impl SuccinctClient {
         gateway_address: Option<&str>,
     ) -> Result<()> {
         // If local mode, submit proof from local directory at proofs/output_{request_id}.json
-        if self.local_relay_mode {
+        if self.local_prove_mode {
             let ethereum_rpc_url = ethereum_rpc_url
                 .expect("Ethereum RPC URL must be provided when relaying a proof in local mode.");
             let wallet =

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -361,7 +361,9 @@ impl SuccinctClient {
             // If it exists, attempt to submit the proof.
             let proof_data = fs::read_to_string(proof_file)?;
             let mut proof_json: serde_json::Value = serde_json::from_str(&proof_data)?;
-            // Strip alphanumeric characters from each of the proof_data fields.
+
+            // Strip alphanumeric characters from each of the proof_data fields (some are formatted
+            // with non-alphanumeric characters, which causes issues when serializing to JSON).
             for (_, value) in proof_json.as_object_mut().unwrap().iter_mut() {
                 if let serde_json::Value::String(s) = value {
                     let re = Regex::new(r"[^a-zA-Z0-9 -]").unwrap();

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -1,0 +1,16 @@
+// List of Succinct Gateway addresses for chains.
+const GATEWAY_ADDRESSES: [(u32, &str); 6] = [
+    (1, "0x6e4f1e9ea315ebfd69d18c2db974eef6105fb803"),
+    (5, "0x6e4f1e9ea315ebfd69d18c2db974eef6105fb803"),
+    (100, "0x6e4f1e9ea315ebfd69d18c2db974eef6105fb803"),
+    (420, "0x6e4f1e9ea315ebfd69d18c2db974eef6105fb803"),
+    (17000, "0x6e4f1e9ea315ebfd69d18c2db974eef6105fb803"),
+    (11155111, "0xaea9288f0b7a8c605c4d474c56e5e74f96bfd4b3"),
+];
+
+pub fn get_gateway_address(chain_id: u32) -> Option<&'static str> {
+    GATEWAY_ADDRESSES
+        .iter()
+        .find(|(id, _)| *id == chain_id)
+        .map(|(_, addr)| *addr)
+}


### PR DESCRIPTION
Add local relaying of proofs to the `SuccinctClient`. For now, local relaying is only supported if local proving is enabled.