### PR TITLE
fix(audit): constrain blake2b variable input length

### DIFF
--- a/plonky2x/core/src/frontend/hash/blake2/curta.rs
+++ b/plonky2x/core/src/frontend/hash/blake2/curta.rs
@@ -194,6 +194,11 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         input: &[ByteVariable],
         length: U32Variable,
     ) -> Bytes32Variable {
+        // Check that length <= input.len(). This is needed to ensure that users cannot
+        // prove the hash of a longer message than they supplied.
+        let supplied_input_length = self.constant::<U32Variable>(input.len() as u32);
+        self.lte(length, supplied_input_length);
+
         let last_chunk = self.compute_blake2b_last_chunk_index(length);
         if self.blake2b_accelerator.is_none() {
             self.blake2b_accelerator = Some(BLAKE2BAccelerator {

--- a/plonky2x/core/src/frontend/hash/blake2/curta.rs
+++ b/plonky2x/core/src/frontend/hash/blake2/curta.rs
@@ -31,8 +31,8 @@ impl<L: PlonkParameters<D>, const D: usize> AirParameters for BLAKE2BAirParamete
 
     type Instruction = UintInstruction;
 
-    const NUM_FREE_COLUMNS: usize = 1527;
-    const EXTENDED_COLUMNS: usize = 708;
+    const NUM_FREE_COLUMNS: usize = 1271;
+    const EXTENDED_COLUMNS: usize = 1476;
 }
 
 impl<L: PlonkParameters<D>, const D: usize> Hash<L, D, 96, true, 4> for BLAKE2B {


### PR DESCRIPTION
Assert the `input_byte_length` is <= the length of the supplied input `ByteVariable` array.

Also, sets the correct column constants for `Blake2B` that were causing tests to fail on https://github.com/succinctlabs/succinctx/pull/331.