### PR TITLE
refactor: `get_fixed_subarray`

### DIFF
--- a/plonky2x/core/src/frontend/vars/array.rs
+++ b/plonky2x/core/src/frontend/vars/array.rs
@@ -264,7 +264,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
     ///         a) i is the index within the subarray.
     ///         b) r^i is the challenge raised to the power of i.
     ///     3) If outside of the subarray, don't add to the accumulator.
-    ///     4) Assert that the accumulator is equal to the accumulator from the hinted subarray.
+    ///     4) Assert that the accumulator is equal to the accumulator from the given subarray.
     pub fn extract_subarray<const ARRAY_SIZE: usize, const SUB_ARRAY_SIZE: usize>(
         &mut self,
         array: &ArrayVariable<Variable, ARRAY_SIZE>,

--- a/plonky2x/core/src/frontend/vars/array.rs
+++ b/plonky2x/core/src/frontend/vars/array.rs
@@ -286,7 +286,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
             seed_bit_len += seed_element_bits.len();
             seed_targets.push(seed_element);
         }
-        // TODO: Seed with 120 bits. Check if this is enough bits of security.
+        // Seed with at least 120 bits. Check if this is enough bits of security.
         const MIN_SEED_BITS: usize = 120;
 
         assert!(seed_bit_len >= MIN_SEED_BITS);

--- a/plonky2x/core/src/frontend/vars/array.rs
+++ b/plonky2x/core/src/frontend/vars/array.rs
@@ -286,7 +286,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
             seed_bit_len += seed_element_bits.len();
             seed_targets.push(seed_element);
         }
-        // Seed with at least 120 bits. Check if this is enough bits of security.
+        // Seed with at least 120 bits. TODO: Check if this is enough bits of security.
         const MIN_SEED_BITS: usize = 120;
 
         assert!(seed_bit_len >= MIN_SEED_BITS);

--- a/plonky2x/core/src/frontend/vars/array.rs
+++ b/plonky2x/core/src/frontend/vars/array.rs
@@ -253,7 +253,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         sub_array
     }
 
-    /// Verify that the subarray is a valid subarray of the array given the start_idx.
+    /// Verify that sub_array is a valid subarray of the array given the start_idx.
     ///
     /// The security of each challenge is log2(field_size) - log2(array_size), so the total security
     /// is (log2(field_size) - log2(array_size)) * num_loops.


### PR DESCRIPTION
Previously, `get_fixed_subarray` was unsafe. 
Now, `get_fixed_subarray` computes the `subarray` from the `start_idx`, constructs the seed by appending the `subarray` to the existing `seed`. Then `extract_subarray` constrains the `subarray` correctly by verifying the accumulator is correct.