### PR TITLE
fix: handle chunk aligned messages for blake2b

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "hex-literal",
  "itoa",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "ruint",
  "serde",
  "tiny-keccak",
@@ -310,7 +310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -320,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -692,7 +692,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2 0.12.2",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "thiserror",
 ]
@@ -846,7 +846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1096,7 +1096,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -1122,7 +1122,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1157,7 +1157,7 @@ dependencies = [
  "hex",
  "k256",
  "log",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "sha3",
@@ -1218,7 +1218,7 @@ dependencies = [
  "hex",
  "hmac",
  "pbkdf2 0.11.0",
- "rand",
+ "rand 0.8.5",
  "scrypt",
  "serde",
  "serde_json",
@@ -1381,7 +1381,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "open-fastrlp",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "serde_json",
@@ -1486,7 +1486,7 @@ dependencies = [
  "elliptic-curve",
  "eth-keystore",
  "ethers-core",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "thiserror",
  "tracing",
@@ -1560,7 +1560,7 @@ dependencies = [
  "bitvec",
  "byteorder",
  "ff_derive",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1602,7 +1602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1662,6 +1662,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -1788,6 +1794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,7 +1819,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1842,7 +1854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2382,7 +2394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -2444,7 +2456,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2454,7 +2466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2682,7 +2694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2783,7 +2795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2887,7 +2899,7 @@ dependencies = [
  "plonky2_field",
  "plonky2_maybe_rayon 0.1.1 (git+https://github.com/mir-protocol/plonky2.git?rev=d2598bd)",
  "plonky2_util",
- "rand",
+ "rand 0.8.5",
  "rand_chacha",
  "serde",
  "serde_json",
@@ -2905,7 +2917,7 @@ dependencies = [
  "itertools 0.11.0",
  "num",
  "plonky2_util",
- "rand",
+ "rand 0.8.5",
  "serde",
  "static_assertions",
  "unroll",
@@ -2960,8 +2972,9 @@ dependencies = [
  "num-bigint 0.4.4",
  "plonky2",
  "plonky2x-derive",
- "rand",
+ "rand 0.8.5",
  "reqwest",
+ "rust-crypto",
  "serde",
  "serde_json",
  "serde_plain",
@@ -3107,7 +3120,7 @@ dependencies = [
  "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.2",
@@ -3139,13 +3152,36 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3155,8 +3191,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3173,7 +3224,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3194,6 +3245,15 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3381,7 +3441,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types 0.12.2",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "ruint-macro",
  "serde",
@@ -3396,6 +3456,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
 
 [[package]]
+name = "rust-crypto"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
+dependencies = [
+ "gcc",
+ "libc",
+ "rand 0.3.23",
+ "rustc-serialize",
+ "time 0.1.45",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3406,6 +3479,12 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustc_version"
@@ -3743,7 +3822,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.34",
 ]
 
 [[package]]
@@ -3819,7 +3898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3831,7 +3910,7 @@ dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
  "thiserror",
- "time",
+ "time 0.3.34",
 ]
 
 [[package]]
@@ -3916,7 +3995,7 @@ dependencies = [
  "num",
  "plonky2",
  "plonky2_maybe_rayon 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand",
+ "rand 0.8.5",
  "serde",
  "subtle-encoding",
 ]
@@ -4142,6 +4221,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -4410,7 +4500,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "rustls",
  "sha1",
  "thiserror",
@@ -4585,6 +4675,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -4965,7 +5061,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "sha1",
- "time",
+ "time 0.3.34",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,11 +588,10 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "9b918671670962b48bc23753aef0c51d072dca6f52f01f800854ada6ddb7f7d3"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -2211,15 +2210,6 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
-name = "jobserver"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -3983,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "starkyx"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/starkyx.git#db15c43146bc29fb4ca47b98f3ace24597ff89d3"
+source = "git+https://github.com/succinctlabs/starkyx.git#dc819a6d23e82603c2467f0975d8302c09b15509"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4954,9 +4944,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/plonky2x/core/Cargo.toml
+++ b/plonky2x/core/Cargo.toml
@@ -55,3 +55,4 @@ plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "d2598bd"
     "gate_testing",
 ] }
 env_logger = "0.10.0"
+rust-crypto = "0.2"

--- a/plonky2x/core/src/frontend/hash/blake2/curta.rs
+++ b/plonky2x/core/src/frontend/hash/blake2/curta.rs
@@ -46,7 +46,10 @@ impl<L: PlonkParameters<D>, const D: usize> Hash<L, D, 96, true, 4> for BLAKE2B 
         builder: &mut CircuitBuilder<L, D>,
         input: &[ByteVariable],
     ) -> Vec<Self::IntVariable> {
-        let num_pad_bytes = 128 - (input.len() % 128);
+        let mut num_pad_bytes = 128 - (input.len() % 128);
+        if input.len() % 128 == 0 && !input.is_empty() {
+            num_pad_bytes = 0;
+        }
 
         let mut padded_message = Vec::new();
         padded_message.extend_from_slice(input);

--- a/plonky2x/core/src/frontend/hash/blake2/curta.rs
+++ b/plonky2x/core/src/frontend/hash/blake2/curta.rs
@@ -392,6 +392,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "ci", ignore)]
     fn test_blake2b_curta_chunk_aligned() {
         let _ = env_logger::builder().is_test(true).try_init();
 

--- a/plonky2x/core/src/frontend/hash/blake2/curta.rs
+++ b/plonky2x/core/src/frontend/hash/blake2/curta.rs
@@ -116,7 +116,7 @@ impl<L: PlonkParameters<D>, const D: usize> Hash<L, D, 96, true, 4> for BLAKE2B 
 
     fn hash(message: Vec<u8>) -> [Self::Integer; 4] {
         let mut num_message_chunks = (message.len() as u64 / 128) + 1;
-        if message.len() % 128 == 0 {
+        if message.len() % 128 == 0 && !message.is_empty() {
             num_message_chunks -= 1;
         }
 
@@ -229,16 +229,24 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         let chunk_size = self.constant::<U32Variable>(128);
         let last_chunk_idx = self.div(input_byte_length, chunk_size);
 
-        // Check to see if the input length is a multiple of 128. If it is, we need to subtract 1
-        // from the last chunk index.
-        let one = self.one();
-        let last_chunk_idx_minus_one = self.sub(last_chunk_idx, one);
+        // Check to see if the input length is a multiple of 128 and it's not zero length. If it is,
+        // we need to subtract 1 from the last chunk index.
 
+        // Find out if the input length is a multiple of 128.
         let mut tmp = self.mul(chunk_size, last_chunk_idx);
         tmp = self.sub(tmp, input_byte_length);
         let is_multiple = self.is_zero(tmp.variable);
 
-        self.select(is_multiple, last_chunk_idx_minus_one, last_chunk_idx)
+        // Find out if the input length is not zero.
+        let is_zero_length = self.is_zero(input_byte_length.variable);
+        let is_not_zero_length = self.not(is_zero_length);
+
+        // Find out if we need to subtract 1 from the last chunk index.
+        let do_minus_one = self.and(is_multiple, is_not_zero_length);
+        let one = self.one();
+        let last_chunk_idx_minus_one = self.sub(last_chunk_idx, one);
+
+        self.select(do_minus_one, last_chunk_idx_minus_one, last_chunk_idx)
     }
 }
 

--- a/plonky2x/core/src/frontend/hash/sha/sha256/curta.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha256/curta.rs
@@ -143,10 +143,13 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         input: &[ByteVariable],
         length: U32Variable,
     ) -> Bytes32Variable {
+        let true_v = self._true();
         // Check that length <= input.len(). This is needed to ensure that users cannot prove the
         // hash of a longer message than they supplied.
         let supplied_input_length = self.constant::<U32Variable>(input.len() as u32);
-        self.lte(length, supplied_input_length);
+        let is_length_valid = self.lte(length, supplied_input_length);
+        self.assert_is_equal(is_length_valid, true_v);
+
         // Extend input's length to the nearest multiple of 64 (if it is not already).
         let mut input = input.to_vec();
         if (input.len() % 64) != 0 {

--- a/plonky2x/core/src/frontend/hash/sha/sha256/curta.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha256/curta.rs
@@ -435,4 +435,37 @@ mod tests {
         circuit.verify(&proof, &input, &output);
         circuit.test_default_serializers();
     }
+
+    #[test]
+    #[cfg_attr(feature = "ci", ignore)]
+    fn test_sha256_diff_sizes() {
+        // Confirm that Curta SHA256 works for all sizes from 0 to 256 bytes.
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let mut builder = CircuitBuilder::<L, D>::new();
+
+        // Generate random Vec of <u8> of size 256 bytes.
+        let mut rng = rand::thread_rng();
+        let msg_bytes: Vec<u8> = (0..256).map(|_| rng.gen()).collect();
+
+        let msg_var = builder.constant::<BytesVariable<256>>(msg_bytes.clone().try_into().unwrap());
+
+        for i in 1..256 {
+            let msg = &msg_bytes.clone()[0..i];
+            let msg_len = builder.constant::<U32Variable>(msg.len() as u32);
+
+            let variable_result = builder.curta_sha256_variable(&msg_var.0, msg_len);
+
+            let fixed_result = builder.curta_sha256(&msg_var[0..i]);
+            let expected_digest = builder.constant::<Bytes32Variable>(H256::from(sha256(msg)));
+
+            builder.assert_is_equal(variable_result, expected_digest);
+            builder.assert_is_equal(fixed_result, expected_digest);
+        }
+
+        let circuit = builder.build();
+        let input = circuit.input();
+        let (proof, output) = circuit.prove(&input);
+        circuit.verify(&proof, &input, &output);
+    }
 }

--- a/plonky2x/core/src/frontend/hash/sha/sha256/curta.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha256/curta.rs
@@ -455,8 +455,8 @@ mod tests {
             let msg_len = builder.constant::<U32Variable>(msg.len() as u32);
 
             let variable_result = builder.curta_sha256_variable(&msg_var.0, msg_len);
-
             let fixed_result = builder.curta_sha256(&msg_var[0..i]);
+
             let expected_digest = builder.constant::<Bytes32Variable>(H256::from(sha256(msg)));
 
             builder.assert_is_equal(variable_result, expected_digest);

--- a/plonky2x/core/src/frontend/hash/sha/sha512/curta.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha512/curta.rs
@@ -432,8 +432,8 @@ mod tests {
             let msg_len = builder.constant::<U32Variable>(msg.len() as u32);
 
             let variable_result = builder.curta_sha512_variable(&msg_var.0, msg_len);
-
             let fixed_result = builder.curta_sha512(&msg_var[0..i]);
+
             let expected_digest = builder.constant::<BytesVariable<64>>(sha512(msg));
 
             builder.assert_is_equal(variable_result, expected_digest);

--- a/plonky2x/core/src/frontend/hash/sha/sha512/curta.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha512/curta.rs
@@ -412,4 +412,37 @@ mod tests {
         let (proof, output) = circuit.prove(&input);
         circuit.verify(&proof, &input, &output);
     }
+
+    #[test]
+    #[cfg_attr(feature = "ci", ignore)]
+    fn test_sha512_diff_sizes() {
+        // Confirm that Curta SHA512 works for all sizes from 0 to 256 bytes.
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let mut builder = DefaultBuilder::new();
+
+        // Generate random Vec of <u8> of size 256 bytes.
+        let mut rng = rand::thread_rng();
+        let msg_bytes: Vec<u8> = (0..256).map(|_| rng.gen()).collect();
+
+        let msg_var = builder.constant::<BytesVariable<256>>(msg_bytes.clone().try_into().unwrap());
+
+        for i in 1..256 {
+            let msg = &msg_bytes.clone()[0..i];
+            let msg_len = builder.constant::<U32Variable>(msg.len() as u32);
+
+            let variable_result = builder.curta_sha512_variable(&msg_var.0, msg_len);
+
+            let fixed_result = builder.curta_sha512(&msg_var[0..i]);
+            let expected_digest = builder.constant::<BytesVariable<64>>(sha512(msg));
+
+            builder.assert_is_equal(variable_result, expected_digest);
+            builder.assert_is_equal(fixed_result, expected_digest);
+        }
+
+        let circuit = builder.build();
+        let input = circuit.input();
+        let (proof, output) = circuit.prove(&input);
+        circuit.verify(&proof, &input, &output);
+    }
 }

--- a/plonky2x/core/src/frontend/hash/sha/sha512/curta.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha512/curta.rs
@@ -152,10 +152,12 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
         input: &[ByteVariable],
         length: U32Variable,
     ) -> BytesVariable<64> {
+        let true_v = self._true();
         // Check that length <= input.len(). This is needed to ensure that users cannot prove the
         // hash of a longer message than they supplied.
         let supplied_input_length = self.constant::<U32Variable>(input.len() as u32);
-        self.lte(length, supplied_input_length);
+        let is_length_valid = self.lte(length, supplied_input_length);
+        self.assert_is_equal(is_length_valid, true_v);
 
         let last_chunk = self.compute_sha512_last_chunk(length);
 


### PR DESCRIPTION
This PR address two issues with blake2b related hash functions:

1) Fixed the case when the message is chunk aligned and not empty.  Basically, when the circuit was calculating the number of chunks of a message (or relatedly the idx of the last chunk), it was doing msg_len / chunk_len.  But if the msg_len is non zero and a multiple of chunk_len, that quotient value should be decremented by one.
2) In the pad_circuit_variable_length function (which is used when handling a blake2b request with variable size, it needed to replace all bytes after the inputted message len with zeros