### PR TITLE
chore: unpin curve25519

### DIFF
--- a/plonky2x/core/Cargo.toml
+++ b/plonky2x/core/Cargo.toml
@@ -19,7 +19,7 @@ plonky2x-derive = { path = "../derive" }
 
 num = { version = "0.4", default-features = false }
 sha2 = "0.10.7"
-curve25519-dalek = "=4.0.0"
+curve25519-dalek = "4"
 ff = { package = "ff", version = "0.13", features = ["derive"] }
 ethers = { version = "2.0" }
 hex = "0.4.3"


### PR DESCRIPTION
Ideally, libraries should have as permissive dependencies as possible. The previous change to =pin curve25519 meant that plonky2x was incompatible with a few dependencies, particularly those that make use of ed25519. With this change, it would allow use to make use of `cargo` for semver compatibility, and any security issues going forward would not need a codechange from the upstream maintainers, just a `cargo update --recursive -p plonky2x`.

I couldn't see any related CVEs with regard to dalek cryptography recently, the last one being in October which was fixed in a revision release.