### PR TITLE
expose plonky2 recursion to the user

### DIFF
--- a/plonky2x/core/src/frontend/recursion/mod.rs
+++ b/plonky2x/core/src/frontend/recursion/mod.rs
@@ -1,4 +1,5 @@
 pub mod extension;
 pub mod fri;
 pub mod hash;
+pub mod plonky2_proof;
 pub mod polynomial;

--- a/plonky2x/core/src/frontend/recursion/plonky2_proof.rs
+++ b/plonky2x/core/src/frontend/recursion/plonky2_proof.rs
@@ -1,0 +1,26 @@
+use crate::frontend::recursion::extension::ExtensionVariable;
+use crate::frontend::recursion::fri::proof::FriProofVariable;
+use crate::frontend::recursion::hash::MerkleCapVariable;
+use crate::prelude::Variable;
+pub struct ProofWithPublicInputsVariable<const D: usize> {
+    proof: ProofVariable<D>, // Add missing generic argument
+    public_inputs: Vec<Variable>,
+}
+
+pub struct ProofVariable<const D: usize> {
+    wires_cap: MerkleCapVariable,
+    plonk_zs_partial_products_cap: MerkleCapVariable,
+    quotient_polys_cap: MerkleCapVariable,
+    openings: OpeningSetVariable<D>,
+    opening_proof: FriProofVariable<D>,
+}
+
+pub struct OpeningSetVariable<const D: usize> {
+    pub constants: Vec<ExtensionVariable<D>>,
+    pub plonk_sigmas: Vec<ExtensionVariable<D>>,
+    pub wires: Vec<ExtensionVariable<D>>,
+    pub plonk_zs: Vec<ExtensionVariable<D>>,
+    pub plonk_zs_next: Vec<ExtensionVariable<D>>,
+    pub partial_products: Vec<ExtensionVariable<D>>,
+    pub quotient_polys: Vec<ExtensionVariable<D>>,
+}

--- a/plonky2x/core/src/frontend/recursion/plonky2_proof.rs
+++ b/plonky2x/core/src/frontend/recursion/plonky2_proof.rs
@@ -3,7 +3,7 @@ use crate::frontend::recursion::fri::proof::FriProofVariable;
 use crate::frontend::recursion::hash::MerkleCapVariable;
 use crate::prelude::Variable;
 pub struct ProofWithPublicInputsVariable<const D: usize> {
-    proof: ProofVariable<D>, // Add missing generic argument
+    proof: ProofVariable<D>,
     public_inputs: Vec<Variable>,
 }
 


### PR DESCRIPTION
goal is to add Mina-style recursion to TendermintX. Seems like we'd want to add proof target to the skip and step circuits, but Plonky2's `ProofWithPublicInputsTarget` type has not been wrapped as a variable for the plonky2X framework.

Forgive me if I misunderstand the P2x framework!