### PR TITLE
chore: curve25519-dalek, plonky2, clippy

### DIFF
--- a/.github/workflows/plonky2x.yml
+++ b/.github/workflows/plonky2x.yml
@@ -31,15 +31,15 @@ jobs:
             ~/.cargo/git/db/
             target/
             ~/.rustup/
-          key: test-rust-nightly-2024-01-25-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: rust-nightly-2024-01-25-
+          key: test-rust-nightly-2024-02-22-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: rust-nightly-2024-02-22-
 
       - name: Install nightly toolchain
         id: rustc-toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2024-01-25
+          toolchain: nightly-2024-02-22
           override: true
 
       - name: Run cargo test
@@ -69,15 +69,15 @@ jobs:
             ~/.cargo/git/db/
             target/
             ~/.rustup/
-          key: clippy-rust-nightly-2024-01-25-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: rust-nightly-2024-01-25-
+          key: clippy-rust-nightly-2024-02-22-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: rust-nightly-2024-02-22-
 
       - name: Install nightly toolchain
         id: rustc-toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2024-01-25
+          toolchain: nightly-2024-02-22
           override: true
           components: rustfmt, clippy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,11 +588,10 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -872,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.0"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622178105f911d937a42cdb140730ba4a3ed2becd8ae6ce39c7d28b5d75d4588"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2211,15 +2210,6 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
-name = "jobserver"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -3984,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "starkyx"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/starkyx.git#b73a875cb81c8c3d84328b99dc56701bba9ae350"
+source = "git+https://github.com/succinctlabs/starkyx.git?branch=ratan/rm-dalek-lock#12e3c7d6de4b7fbb7cf6887035b6974484f43968"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "starkyx"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/starkyx.git?branch=ratan/rm-dalek-lock#9f5989eb9ccc56d0db10c2fa84414bab366e8a17"
+source = "git+https://github.com/succinctlabs/starkyx.git#e28bd667ca01da4e6cc782ab19f97d2f3fd6127e"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,7 +2893,7 @@ dependencies = [
  "log",
  "num",
  "plonky2_field",
- "plonky2_maybe_rayon 0.2.0",
+ "plonky2_maybe_rayon 0.2.0 (git+https://github.com/mir-protocol/plonky2.git)",
  "plonky2_util",
  "rand 0.8.5",
  "rand_chacha",
@@ -2920,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "plonky2_maybe_rayon"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194db0cbdd974e92d897cd92b74adb3968dc1b967315eb280357c49a7637994e"
+checksum = "92ff44a90aaca13e10e7ddf8fab815ba1b404c3f7c3ca82aaf11c46beabaa923"
 dependencies = [
  "rayon",
 ]
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "starkyx"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/starkyx.git#e28bd667ca01da4e6cc782ab19f97d2f3fd6127e"
+source = "git+https://github.com/succinctlabs/starkyx.git#ad8eb4bae41268dcb2964dab52e66d4e551abf39"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3984,7 +3984,7 @@ dependencies = [
  "log",
  "num",
  "plonky2",
- "plonky2_maybe_rayon 0.1.1",
+ "plonky2_maybe_rayon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5",
  "serde",
  "subtle-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -113,7 +113,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -352,7 +352,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -379,13 +379,13 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.1"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c764d619ca78fccbf3069b37bd7af92577f044bb15236036662d79b6559f25b7"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "byte-slice-cast"
@@ -588,10 +588,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -611,7 +612,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -655,7 +656,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -724,9 +725,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "const-hex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d59688ad0945eaf6b84cb44fedbe93484c81b48970e98f09db8a22832d7961"
+checksum = "efbd12d49ab0eaf8193ba9175e45f56bbc2e4b27d57b8cfe62aa47942a46b9a9"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -743,9 +744,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
 dependencies = [
  "const-random-macro",
 ]
@@ -894,14 +895,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c376d08ea6aa96aafe61237c7200d1241cb177b7d3a542d791f2d118e9cbb955"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -909,27 +910,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33043dcd19068b8192064c704b3f83eb464f91f1ff527b44a4e2b08d9cdb8855"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a91391accf613803c2a9bf9abccdbaa07c54b4244a5b64883f9c3c137c86be"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -981,12 +982,6 @@ dependencies = [
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1341,7 +1336,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.50",
+ "syn 2.0.52",
  "toml",
  "walkdir",
 ]
@@ -1359,7 +1354,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1385,7 +1380,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.50",
+ "syn 2.0.52",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -1740,7 +1735,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1757,9 +1752,9 @@ checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
  "gloo-timers",
  "send_wrapper 0.4.0",
@@ -1869,7 +1864,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -1919,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1958,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -2143,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2182,7 +2177,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2212,10 +2207,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "js-sys"
-version = "0.3.68"
+name = "jobserver"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2269,31 +2273,33 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
  "bit-set",
- "diff",
  "ena",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.7.5",
+ "regex-syntax",
  "string_cache",
  "term",
  "tiny-keccak",
  "unicode-xid",
+ "walkdir",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2342,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "md-5"
@@ -2379,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -2513,7 +2519,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -2535,7 +2541,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2601,7 +2607,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2612,9 +2618,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.100"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae94056a791d0e1217d18b6cbdccb02c61e3054fc69893607f4067e3bb0b1fd1"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -2739,9 +2745,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2755,7 +2761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -2798,7 +2804,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2821,22 +2827,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2875,8 +2881,8 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "plonky2"
-version = "0.1.4"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=d2598bd#d2598bded0cb24d36b0a9900e8ffd104c470831b"
+version = "0.2.0"
+source = "git+https://github.com/mir-protocol/plonky2.git#62ffe11a984dbc0e6fe92d812fa8da78b7ba73c7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2887,12 +2893,11 @@ dependencies = [
  "log",
  "num",
  "plonky2_field",
- "plonky2_maybe_rayon 0.1.1 (git+https://github.com/mir-protocol/plonky2.git?rev=d2598bd)",
+ "plonky2_maybe_rayon 0.2.0",
  "plonky2_util",
  "rand 0.8.5",
  "rand_chacha",
  "serde",
- "serde_json",
  "static_assertions",
  "unroll",
  "web-time",
@@ -2900,8 +2905,8 @@ dependencies = [
 
 [[package]]
 name = "plonky2_field"
-version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=d2598bd#d2598bded0cb24d36b0a9900e8ffd104c470831b"
+version = "0.2.0"
+source = "git+https://github.com/mir-protocol/plonky2.git#62ffe11a984dbc0e6fe92d812fa8da78b7ba73c7"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -2924,16 +2929,16 @@ dependencies = [
 
 [[package]]
 name = "plonky2_maybe_rayon"
-version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=d2598bd#d2598bded0cb24d36b0a9900e8ffd104c470831b"
+version = "0.2.0"
+source = "git+https://github.com/mir-protocol/plonky2.git#62ffe11a984dbc0e6fe92d812fa8da78b7ba73c7"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "plonky2_util"
-version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=d2598bd#d2598bded0cb24d36b0a9900e8ffd104c470831b"
+version = "0.2.0"
+source = "git+https://github.com/mir-protocol/plonky2.git#62ffe11a984dbc0e6fe92d812fa8da78b7ba73c7"
 
 [[package]]
 name = "plonky2x"
@@ -2983,7 +2988,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3011,7 +3016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3113,7 +3118,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.2",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3219,9 +3224,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -3275,25 +3280,19 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -3418,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
+checksum = "49b1d9521f889713d1221270fdd63370feca7e5c71a18745343402fa86e4f04f"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -3442,9 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "ruint-macro"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
+checksum = "f86854cf50259291520509879a5c294c3c9a4c334e9ff65071c51e42ef1e2343"
 
 [[package]]
 name = "rust-crypto"
@@ -3754,7 +3753,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3808,7 +3807,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3825,7 +3824,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3927,12 +3926,12 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3974,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "starkyx"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/starkyx.git?branch=ratan/rm-dalek-lock#12e3c7d6de4b7fbb7cf6887035b6974484f43968"
+source = "git+https://github.com/succinctlabs/starkyx.git?branch=ratan/rm-dalek-lock#9f5989eb9ccc56d0db10c2fa84414bab366e8a17"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3985,7 +3984,7 @@ dependencies = [
  "log",
  "num",
  "plonky2",
- "plonky2_maybe_rayon 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plonky2_maybe_rayon 0.1.1",
  "rand 0.8.5",
  "serde",
  "subtle-encoding",
@@ -4041,7 +4040,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4108,9 +4107,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4126,7 +4125,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4164,9 +4163,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4211,7 +4210,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4307,7 +4306,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4386,7 +4385,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -4397,7 +4396,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -4408,7 +4407,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -4419,11 +4418,11 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.2",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -4451,7 +4450,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4650,9 +4649,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -4681,9 +4680,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4691,24 +4690,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4718,9 +4717,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4728,28 +4727,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4757,9 +4756,9 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4808,7 +4807,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -4826,7 +4825,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -4846,17 +4845,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -4867,9 +4866,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4879,9 +4878,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4891,9 +4890,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4903,9 +4902,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4915,9 +4914,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4927,9 +4926,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4939,9 +4938,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
@@ -4954,9 +4953,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4191c47f15cc3ec71fcb4913cb83d58def65dd3787610213c649283b5ce178"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]
@@ -5022,7 +5021,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5042,7 +5041,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/plonky2x/core/Cargo.toml
+++ b/plonky2x/core/Cargo.toml
@@ -13,7 +13,7 @@ std = ["plonky2/std", "itertools/use_std"]
 timing = ["plonky2/timing"]
 
 [dependencies]
-plonky2 = {git = "https://github.com/mir-protocol/plonky2.git", default-features = false, rev = "d2598bd"}
+plonky2 = {git = "https://github.com/mir-protocol/plonky2.git", version = "0.2.0", default-features = false}
 plonky2x-derive = {path = "../derive"}
 starkyx = {git = "https://github.com/succinctlabs/starkyx.git", branch = "ratan/rm-dalek-lock"}
 
@@ -52,7 +52,7 @@ uuid = {version = "1.4.1", features = ["serde"]}
 
 [dev-dependencies]
 env_logger = "0.10.0"
-plonky2 = {git = "https://github.com/mir-protocol/plonky2.git", rev = "d2598bd", features = [
+plonky2 = {git = "https://github.com/mir-protocol/plonky2.git", version = "0.2.0", features = [
   "gate_testing",
 ]}
 rust-crypto = "0.2"

--- a/plonky2x/core/Cargo.toml
+++ b/plonky2x/core/Cargo.toml
@@ -1,58 +1,58 @@
 [package]
+edition = "2021"
 name = "plonky2x"
 version = "0.1.0"
-edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+ci = []
 default = ["parallel", "std", "timing"]
 parallel = ["plonky2/parallel"]
 std = ["plonky2/std", "itertools/use_std"]
 timing = ["plonky2/timing"]
-ci = []
 
 [dependencies]
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", default-features = false, rev = "d2598bd" }
-starkyx = { git = "https://github.com/succinctlabs/starkyx.git", branch = "ratan/rm-dalek-lock"  }
-plonky2x-derive = { path = "../derive" }
+plonky2 = {git = "https://github.com/mir-protocol/plonky2.git", default-features = false, rev = "d2598bd"}
+plonky2x-derive = {path = "../derive"}
+starkyx = {git = "https://github.com/succinctlabs/starkyx.git", branch = "ratan/rm-dalek-lock"}
 
-num = { version = "0.4", default-features = false }
-sha2 = "0.10.7"
-curve25519-dalek = "4.1.0"
-ff = { package = "ff", version = "0.13", features = ["derive"] }
-ethers = { version = "2.0" }
-hex = "0.4.3"
-log = { version = "0.4.14", default-features = false }
-rand = { version = "0.8.4", package = "rand" }
-itertools = { version = "0.10.0", default-features = false }
-serde = { version = "1.0.187", features = ["derive"] }
-serde_json = "1.0.103"
-tokio = { version = "1", features = ["full"] }
 anyhow = "1.0.75"
-reqwest = { version = "0.11.4", features = ["blocking", "json"] }
 array-macro = "2.1.5"
-tracing = "0.1.37"
-num-bigint = { version = "0.4", features = ["rand"] }
-base64 = "0.13"
-futures = "0.3.28"
-lazy_static = "1.4.0"
-backtrace = "0.3"
-env_logger = "0.10.0"
-clap = { version = "4.4.0", features = ["derive"] }
-dotenv = "0.15.0"
-serde_with = "3.3.0"
-bincode = "1.3.3"
-uuid = { version = "1.4.1", features = ["serde"] }
-serde_plain = "1.0.2"
-ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 async-trait = "0.1.73"
+backtrace = "0.3"
+base64 = "0.13"
+bincode = "1.3.3"
+clap = {version = "4.4.0", features = ["derive"]}
+curve25519-dalek = "4"
 digest = "0.10.7"
+dotenv = "0.15.0"
+ed25519-dalek = {version = "2.0.0", features = ["rand_core"]}
+env_logger = "0.10.0"
+ethers = {version = "2.0"}
+ff = {package = "ff", version = "0.13", features = ["derive"]}
+futures = "0.3.28"
+hex = "0.4.3"
+itertools = {version = "0.10.0", default-features = false}
+lazy_static = "1.4.0"
+log = {version = "0.4.14", default-features = false}
+num = {version = "0.4", default-features = false}
+num-bigint = {version = "0.4", features = ["rand"]}
+rand = {version = "0.8.4", package = "rand"}
+reqwest = {version = "0.11.4", features = ["blocking", "json"]}
+serde = {version = "1.0.187", features = ["derive"]}
+serde_json = "1.0.103"
+serde_plain = "1.0.2"
+serde_with = "3.3.0"
+sha2 = "0.10.7"
 sha256 = "1.4.0"
+tokio = {version = "1", features = ["full"]}
+tracing = "0.1.37"
+uuid = {version = "1.4.1", features = ["serde"]}
 
 [dev-dependencies]
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "d2598bd", features = [
-    "gate_testing",
-] }
 env_logger = "0.10.0"
+plonky2 = {git = "https://github.com/mir-protocol/plonky2.git", rev = "d2598bd", features = [
+  "gate_testing",
+]}
 rust-crypto = "0.2"

--- a/plonky2x/core/Cargo.toml
+++ b/plonky2x/core/Cargo.toml
@@ -14,12 +14,12 @@ ci = []
 
 [dependencies]
 plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", default-features = false, rev = "d2598bd" }
-starkyx = { git = "https://github.com/succinctlabs/starkyx.git" }
+starkyx = { git = "https://github.com/succinctlabs/starkyx.git", branch = "ratan/rm-dalek-lock"  }
 plonky2x-derive = { path = "../derive" }
 
 num = { version = "0.4", default-features = false }
 sha2 = "0.10.7"
-curve25519-dalek = "=4.1.0"
+curve25519-dalek = "4.1.0"
 ff = { package = "ff", version = "0.13", features = ["derive"] }
 ethers = { version = "2.0" }
 hex = "0.4.3"

--- a/plonky2x/core/Cargo.toml
+++ b/plonky2x/core/Cargo.toml
@@ -13,9 +13,9 @@ std = ["plonky2/std", "itertools/use_std"]
 timing = ["plonky2/timing"]
 
 [dependencies]
-plonky2 = {git = "https://github.com/mir-protocol/plonky2.git", version = "0.2.0", default-features = false}
-plonky2x-derive = {path = "../derive"}
-starkyx = {git = "https://github.com/succinctlabs/starkyx.git", branch = "ratan/rm-dalek-lock"}
+plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", version = "0.2.0", default-features = false }
+plonky2x-derive = { path = "../derive" }
+starkyx = { git = "https://github.com/succinctlabs/starkyx.git" }
 
 anyhow = "1.0.75"
 array-macro = "2.1.5"
@@ -23,36 +23,36 @@ async-trait = "0.1.73"
 backtrace = "0.3"
 base64 = "0.13"
 bincode = "1.3.3"
-clap = {version = "4.4.0", features = ["derive"]}
+clap = { version = "4.4.0", features = ["derive"] }
 curve25519-dalek = "4"
 digest = "0.10.7"
 dotenv = "0.15.0"
-ed25519-dalek = {version = "2.0.0", features = ["rand_core"]}
+ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 env_logger = "0.10.0"
-ethers = {version = "2.0"}
-ff = {package = "ff", version = "0.13", features = ["derive"]}
+ethers = { version = "2.0" }
+ff = { package = "ff", version = "0.13", features = ["derive"] }
 futures = "0.3.28"
 hex = "0.4.3"
-itertools = {version = "0.10.0", default-features = false}
+itertools = { version = "0.10.0", default-features = false }
 lazy_static = "1.4.0"
-log = {version = "0.4.14", default-features = false}
-num = {version = "0.4", default-features = false}
-num-bigint = {version = "0.4", features = ["rand"]}
-rand = {version = "0.8.4", package = "rand"}
-reqwest = {version = "0.11.4", features = ["blocking", "json"]}
-serde = {version = "1.0.187", features = ["derive"]}
+log = { version = "0.4.14", default-features = false }
+num = { version = "0.4", default-features = false }
+num-bigint = { version = "0.4", features = ["rand"] }
+rand = { version = "0.8.4", package = "rand" }
+reqwest = { version = "0.11.4", features = ["blocking", "json"] }
+serde = { version = "1.0.187", features = ["derive"] }
 serde_json = "1.0.103"
 serde_plain = "1.0.2"
 serde_with = "3.3.0"
 sha2 = "0.10.7"
 sha256 = "1.4.0"
-tokio = {version = "1", features = ["full"]}
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1.37"
-uuid = {version = "1.4.1", features = ["serde"]}
+uuid = { version = "1.4.1", features = ["serde"] }
 
 [dev-dependencies]
 env_logger = "0.10.0"
-plonky2 = {git = "https://github.com/mir-protocol/plonky2.git", version = "0.2.0", features = [
+plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", version = "0.2.0", features = [
   "gate_testing",
-]}
+] }
 rust-crypto = "0.2"

--- a/plonky2x/core/src/backend/circuit/build.rs
+++ b/plonky2x/core/src/backend/circuit/build.rs
@@ -298,11 +298,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuild<L, D> {
 #[cfg(test)]
 pub(crate) mod tests {
 
-    use plonky2::field::types::Field;
-
-    use crate::backend::circuit::serialization::{GateRegistry, HintRegistry};
     use crate::backend::circuit::CircuitBuild;
-    use crate::frontend::builder::DefaultBuilder;
     use crate::prelude::*;
 
     type L = DefaultParameters;

--- a/plonky2x/core/src/backend/circuit/mock.rs
+++ b/plonky2x/core/src/backend/circuit/mock.rs
@@ -65,7 +65,6 @@ impl<L: PlonkParameters<D>, const D: usize> MockCircuitBuild<L, D> {
 pub(crate) mod tests {
 
     use log::debug;
-    use plonky2::field::types::Field;
 
     use crate::prelude::*;
     use crate::utils;

--- a/plonky2x/core/src/backend/function/mod.rs
+++ b/plonky2x/core/src/backend/function/mod.rs
@@ -18,7 +18,7 @@ use crate::backend::circuit::*;
 use crate::backend::function::args::{Args, Commands};
 use crate::backend::wrapper::wrap::WrappedCircuit;
 use crate::frontend::builder::CircuitIO;
-use crate::prelude::{CircuitBuilder, GateRegistry, HintRegistry};
+use crate::prelude::CircuitBuilder;
 
 /// `Plonky2xFunction`s have all necessary code for a circuit to be deployed end-to-end.
 pub trait Plonky2xFunction {

--- a/plonky2x/core/src/backend/wrapper/wrap.rs
+++ b/plonky2x/core/src/backend/wrapper/wrap.rs
@@ -255,7 +255,6 @@ impl<L: PlonkParameters<D>, const D: usize> WrappedOutput<L, D> {
 mod tests {
     use super::*;
     use crate::backend::circuit::{DefaultParameters, Groth16WrapperParameters};
-    use crate::frontend::builder::CircuitBuilder;
     use crate::utils;
 
     #[test]

--- a/plonky2x/core/src/frontend/builder/mod.rs
+++ b/plonky2x/core/src/frontend/builder/mod.rs
@@ -410,9 +410,7 @@ impl<L: PlonkParameters<D>, const D: usize> Default for CircuitBuilder<L, D> {
 pub(crate) mod tests {
 
     use log::debug;
-    use plonky2::field::types::Field;
 
-    use super::DefaultBuilder;
     use crate::prelude::*;
     use crate::utils;
 

--- a/plonky2x/core/src/frontend/builder/permutation.rs
+++ b/plonky2x/core/src/frontend/builder/permutation.rs
@@ -124,10 +124,7 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
 #[cfg(test)]
 pub(crate) mod tests {
 
-    use plonky2::field::types::Field;
-
     use crate::frontend::extension::CubicExtensionVariable;
-    use crate::frontend::uint::uint32::U32Variable;
     use crate::prelude::*;
     use crate::utils;
 

--- a/plonky2x/core/src/frontend/builder/watch.rs
+++ b/plonky2x/core/src/frontend/builder/watch.rs
@@ -186,9 +186,7 @@ impl<L: PlonkParameters<D>, V: CircuitVariable, const D: usize> SimpleGenerator<
 #[cfg(test)]
 mod tests {
     use log::{debug, Level};
-    use plonky2::field::types::Field;
 
-    use crate::frontend::builder::DefaultBuilder;
     use crate::prelude::*;
     use crate::utils;
 

--- a/plonky2x/core/src/frontend/curta/builder.rs
+++ b/plonky2x/core/src/frontend/curta/builder.rs
@@ -57,7 +57,6 @@ impl<L: PlonkParameters<D>, const D: usize> CircuitBuilder<L, D> {
 
 #[cfg(test)]
 mod tests {
-    use plonky2::field::goldilocks_field::GoldilocksField;
     use plonky2::util::timing::TimingTree;
     use serde::{Deserialize, Serialize};
     use starkyx::chip::memory::time::Time;

--- a/plonky2x/core/src/frontend/curta/proof.rs
+++ b/plonky2x/core/src/frontend/curta/proof.rs
@@ -728,7 +728,6 @@ mod tests {
     use starkyx::chip::register::element::ElementRegister;
     use starkyx::chip::register::{Register, RegisterSerializable};
     use starkyx::chip::trace::generator::ArithmeticGenerator;
-    use starkyx::chip::AirParameters;
     use starkyx::math::goldilocks::cubic::GoldilocksCubicParameters;
     use starkyx::plonky2::stark::config::{
         CurtaPoseidonGoldilocksConfig, PoseidonGoldilocksStarkConfig,

--- a/plonky2x/core/src/frontend/eth/beacon/vars/header.rs
+++ b/plonky2x/core/src/frontend/eth/beacon/vars/header.rs
@@ -81,7 +81,7 @@ mod test {
     use ethers::types::U64;
 
     use super::*;
-    use crate::prelude::{CircuitBuilder, DefaultParameters, PlonkParameters};
+    use crate::prelude::DefaultParameters;
     use crate::utils::eth::beacon::BeaconClient;
 
     type L = DefaultParameters;

--- a/plonky2x/core/src/frontend/eth/mpt/reference.rs
+++ b/plonky2x/core/src/frontend/eth/mpt/reference.rs
@@ -144,7 +144,7 @@ mod tests {
     use ethers::types::Bytes;
 
     use super::super::utils::{read_fixture, EIP1186ProofResponse};
-    use super::{get, *};
+    use super::*;
     use crate::frontend::eth::utils::u256_to_h256_be;
     use crate::utils::bytes32;
 

--- a/plonky2x/core/src/frontend/hash/blake2/curta.rs
+++ b/plonky2x/core/src/frontend/hash/blake2/curta.rs
@@ -13,11 +13,10 @@ use starkyx::machine::hash::blake::blake2b::pure::BLAKE2BPure;
 use starkyx::machine::hash::blake::blake2b::utils::BLAKE2BUtil;
 use starkyx::machine::hash::blake::blake2b::BLAKE2B;
 
-use crate::backend::circuit::PlonkParameters;
 use crate::frontend::hash::curta::accelerator::HashAccelerator;
 use crate::frontend::hash::curta::request::HashRequest;
 use crate::frontend::hash::curta::Hash;
-use crate::frontend::vars::{Bytes32Variable, EvmVariable};
+use crate::frontend::vars::EvmVariable;
 use crate::prelude::*;
 
 pub type BLAKE2BAccelerator = HashAccelerator<U64Variable, 4>;

--- a/plonky2x/core/src/frontend/hash/keccak/mod.rs
+++ b/plonky2x/core/src/frontend/hash/keccak/mod.rs
@@ -47,7 +47,6 @@ mod tests {
 
     use super::*;
     use crate::backend::circuit::DefaultParameters;
-    use crate::prelude::CircuitBuilder;
     use crate::utils::bytes32;
 
     type L = DefaultParameters;

--- a/plonky2x/core/src/frontend/hash/sha/sha256/curta.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha256/curta.rs
@@ -200,8 +200,7 @@ mod tests {
     use ethers::types::H256;
     use rand::{thread_rng, Rng};
 
-    use crate::backend::circuit::{CircuitBuild, DefaultParameters};
-    use crate::frontend::vars::Bytes32Variable;
+    use crate::backend::circuit::CircuitBuild;
     use crate::prelude::*;
     use crate::utils::hash::sha256;
     use crate::utils::{bytes, bytes32};

--- a/plonky2x/core/src/frontend/hash/sha/sha256/mod.rs
+++ b/plonky2x/core/src/frontend/hash/sha/sha256/mod.rs
@@ -159,7 +159,7 @@ mod tests {
     use rand::{thread_rng, Rng};
 
     use super::*;
-    use crate::prelude::{ByteVariable, CircuitBuilder, DefaultParameters, U32Variable};
+    use crate::prelude::{DefaultParameters, U32Variable};
     use crate::utils::hash::sha256;
 
     type L = DefaultParameters;

--- a/plonky2x/core/src/frontend/hint/simple/hint.rs
+++ b/plonky2x/core/src/frontend/hint/simple/hint.rs
@@ -73,7 +73,6 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::frontend::vars::ValueStream;
     use crate::prelude::*;
 
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/plonky2x/core/src/frontend/hint/simple/serializer.rs
+++ b/plonky2x/core/src/frontend/hint/simple/serializer.rs
@@ -62,7 +62,6 @@ mod tests {
 
     use super::*;
     use crate::backend::circuit::CircuitBuild;
-    use crate::frontend::vars::ValueStream;
     use crate::prelude::*;
 
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/plonky2x/core/src/frontend/hint/synchronous.rs
+++ b/plonky2x/core/src/frontend/hint/synchronous.rs
@@ -57,7 +57,6 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::frontend::vars::{ValueStream, VariableStream};
     use crate::prelude::*;
 
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/plonky2x/core/src/frontend/merkle/simple.rs
+++ b/plonky2x/core/src/frontend/merkle/simple.rs
@@ -133,7 +133,6 @@ mod tests {
 
     use std::env;
 
-    use crate::backend::circuit::DefaultParameters;
     use crate::frontend::merkle::simple::SimpleMerkleTree;
     use crate::prelude::*;
 

--- a/plonky2x/core/src/frontend/merkle/tendermint.rs
+++ b/plonky2x/core/src/frontend/merkle/tendermint.rs
@@ -222,7 +222,6 @@ mod tests {
     use ethers::types::H256;
     use itertools::Itertools;
 
-    use crate::backend::circuit::DefaultParameters;
     use crate::frontend::merkle::tendermint::TendermintMerkleTree;
     use crate::frontend::merkle::tree::{InclusionProof, MerkleInclusionProofVariable};
     use crate::prelude::*;

--- a/plonky2x/core/src/frontend/merkle/tree.rs
+++ b/plonky2x/core/src/frontend/merkle/tree.rs
@@ -1,5 +1,3 @@
-use plonky2::hash::hash_types::RichField;
-
 use crate::prelude::*;
 
 #[derive(Clone, Debug, CircuitVariable)]

--- a/plonky2x/core/src/frontend/recursion/extension.rs
+++ b/plonky2x/core/src/frontend/recursion/extension.rs
@@ -1,7 +1,6 @@
 use plonky2::field::extension::FieldExtension;
 use plonky2::iop::ext_target::ExtensionTarget;
 
-use crate::frontend::vars::ValueStream;
 use crate::prelude::*;
 
 #[derive(Debug, Clone, Eq, PartialEq, CircuitVariable)]

--- a/plonky2x/core/src/frontend/recursion/fri/proof.rs
+++ b/plonky2x/core/src/frontend/recursion/fri/proof.rs
@@ -554,7 +554,6 @@ impl<const D: usize> From<FriProofVariable<D>> for FriProofTarget<D> {
 
 #[cfg(test)]
 mod tests {
-    use plonky2::fri::proof::FriProofTarget;
     use plonky2::hash::poseidon::PoseidonHash;
     use plonky2::plonk::plonk_common::salt_size;
 

--- a/plonky2x/core/src/frontend/recursion/hash.rs
+++ b/plonky2x/core/src/frontend/recursion/hash.rs
@@ -4,7 +4,6 @@ use plonky2::hash::merkle_tree::MerkleCap;
 use plonky2::plonk::config::AlgebraicHasher;
 
 use crate::frontend::hash::poseidon::poseidon256::PoseidonHashOutVariable;
-use crate::frontend::vars::{OutputVariableStream, VariableStream};
 use crate::prelude::*;
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/plonky2x/core/src/frontend/uint/num/biguint/mod.rs
+++ b/plonky2x/core/src/frontend/uint/num/biguint/mod.rs
@@ -575,9 +575,8 @@ impl ReadBigUint for Buffer<'_> {
 
 #[cfg(test)]
 mod tests {
-    use num::{BigUint, FromPrimitive, Integer};
+    use num::FromPrimitive;
     use plonky2::iop::witness::PartialWitness;
-    use plonky2::plonk::circuit_builder::CircuitBuilder;
     use plonky2::plonk::circuit_data::CircuitConfig;
     use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
     use rand::rngs::OsRng;

--- a/plonky2x/core/src/frontend/uint/num/u32/gadgets/arithmetic_u32.rs
+++ b/plonky2x/core/src/frontend/uint/num/u32/gadgets/arithmetic_u32.rs
@@ -1,6 +1,4 @@
-use alloc::string::{String, ToString};
 use alloc::vec;
-use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use plonky2::field::extension::Extendable;

--- a/plonky2x/core/src/frontend/uint/num/u32/gadgets/multiple_comparison.rs
+++ b/plonky2x/core/src/frontend/uint/num/u32/gadgets/multiple_comparison.rs
@@ -1,5 +1,4 @@
 use alloc::vec;
-use alloc::vec::Vec;
 
 use plonky2::field::extension::Extendable;
 use plonky2::hash::hash_types::RichField;

--- a/plonky2x/core/src/frontend/uint/num/u32/gadgets/range_check.rs
+++ b/plonky2x/core/src/frontend/uint/num/u32/gadgets/range_check.rs
@@ -1,5 +1,4 @@
 use alloc::vec;
-use alloc::vec::Vec;
 
 use plonky2::field::extension::Extendable;
 use plonky2::hash::hash_types::RichField;

--- a/plonky2x/core/src/frontend/uint/num/u32/gates/add_many_u32.rs
+++ b/plonky2x/core/src/frontend/uint/num/u32/gates/add_many_u32.rs
@@ -1,6 +1,4 @@
 use alloc::format;
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use itertools::unfold;

--- a/plonky2x/core/src/frontend/uint/num/u32/gates/arithmetic_u32.rs
+++ b/plonky2x/core/src/frontend/uint/num/u32/gates/arithmetic_u32.rs
@@ -1,5 +1,3 @@
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::marker::PhantomData;
 

--- a/plonky2x/core/src/frontend/uint/num/u32/gates/comparison.rs
+++ b/plonky2x/core/src/frontend/uint/num/u32/gates/comparison.rs
@@ -1,5 +1,3 @@
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::marker::PhantomData;
 

--- a/plonky2x/core/src/frontend/uint/num/u32/gates/range_check_u32.rs
+++ b/plonky2x/core/src/frontend/uint/num/u32/gates/range_check_u32.rs
@@ -1,5 +1,3 @@
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::marker::PhantomData;
 
@@ -242,7 +240,7 @@ mod tests {
     use itertools::unfold;
     use plonky2::field::extension::quartic::QuarticExtension;
     use plonky2::field::goldilocks_field::GoldilocksField;
-    use plonky2::field::types::{Field, Sample};
+    use plonky2::field::types::Sample;
     use plonky2::gates::gate_testing::{test_eval_fns, test_low_degree};
     use plonky2::hash::hash_types::HashOut;
     use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};

--- a/plonky2x/core/src/frontend/uint/num/u32/gates/subtraction_u32.rs
+++ b/plonky2x/core/src/frontend/uint/num/u32/gates/subtraction_u32.rs
@@ -1,5 +1,3 @@
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::marker::PhantomData;
 

--- a/plonky2x/core/src/frontend/uint/num/u32/serialization.rs
+++ b/plonky2x/core/src/frontend/uint/num/u32/serialization.rs
@@ -1,5 +1,3 @@
-use alloc::vec::Vec;
-
 use plonky2::util::serialization::{Buffer, IoResult, Read, Write};
 
 use crate::frontend::uint::num::u32::gadgets::arithmetic_u32::U32Target;

--- a/plonky2x/core/src/frontend/uint/uint32.rs
+++ b/plonky2x/core/src/frontend/uint/uint32.rs
@@ -1,16 +1,12 @@
 use std::fmt::Debug;
 
 use itertools::Itertools;
-use plonky2::hash::hash_types::RichField;
 use plonky2::iop::target::BoolTarget;
 
-use super::uint64::U64Variable;
-use crate::backend::circuit::PlonkParameters;
-use crate::frontend::builder::CircuitBuilder;
 use crate::frontend::uint::num::biguint::{BigUintTarget, CircuitBuilderBiguint};
 use crate::frontend::uint::num::u32::gadgets::arithmetic_u32::{CircuitBuilderU32, U32Target};
 use crate::frontend::uint::num::u32::gadgets::multiple_comparison::list_lte_circuit;
-use crate::frontend::vars::{CircuitVariable, EvmVariable, Variable};
+use crate::frontend::vars::EvmVariable;
 use crate::prelude::*;
 
 /// A variable in the circuit representing a u32 value.
@@ -277,8 +273,6 @@ impl U32Variable {
 mod tests {
     use rand::Rng;
 
-    use super::U32Variable;
-    use crate::backend::circuit::DefaultParameters;
     use crate::frontend::vars::EvmVariable;
     use crate::prelude::*;
     use crate::utils::setup_logger;

--- a/plonky2x/core/src/frontend/vars/array.rs
+++ b/plonky2x/core/src/frontend/vars/array.rs
@@ -368,13 +368,10 @@ mod tests {
 
     use ethers::types::U256;
     use log::debug;
-    use plonky2::field::types::Field;
     use rand::rngs::OsRng;
     use rand::Rng;
 
     use super::*;
-    use crate::backend::circuit::DefaultParameters;
-    use crate::frontend::vars::U256Variable;
     use crate::prelude::*;
     use crate::utils;
 

--- a/plonky2x/core/src/frontend/vars/boolean.rs
+++ b/plonky2x/core/src/frontend/vars/boolean.rs
@@ -130,7 +130,6 @@ impl<L: PlonkParameters<D>, const D: usize> Not<L, D> for BoolVariable {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::circuit::DefaultParameters;
     use crate::prelude::*;
 
     type L = DefaultParameters;

--- a/plonky2x/core/src/frontend/vars/byte.rs
+++ b/plonky2x/core/src/frontend/vars/byte.rs
@@ -293,7 +293,6 @@ impl<L: PlonkParameters<D>, const D: usize> Zero<L, D> for ByteVariable {
 mod tests {
     use itertools::Itertools;
 
-    use crate::backend::circuit::DefaultParameters;
     use crate::prelude::*;
 
     type L = DefaultParameters;

--- a/plonky2x/core/src/frontend/vars/bytes.rs
+++ b/plonky2x/core/src/frontend/vars/bytes.rs
@@ -291,7 +291,6 @@ impl<L: PlonkParameters<D>, const D: usize, const N: usize> RotateRight<L, D, us
 mod tests {
     use rand::{thread_rng, Rng};
 
-    use crate::backend::circuit::DefaultParameters;
     use crate::prelude::*;
 
     type L = DefaultParameters;

--- a/plonky2x/core/src/frontend/vars/mod.rs
+++ b/plonky2x/core/src/frontend/vars/mod.rs
@@ -188,7 +188,6 @@ pub trait SSZVariable: CircuitVariable {
 
 #[cfg(test)]
 mod tests {
-    use crate::frontend::vars::ArrayVariable;
     use crate::prelude::*;
 
     #[test]

--- a/plonky2x/core/src/utils/eth/beacon/mod.rs
+++ b/plonky2x/core/src/utils/eth/beacon/mod.rs
@@ -776,7 +776,6 @@ mod tests {
 
     use std::env;
 
-    use anyhow::Result;
     use log::debug;
 
     use super::*;

--- a/plonky2x/core/src/utils/lido/mod.rs
+++ b/plonky2x/core/src/utils/lido/mod.rs
@@ -1,10 +1,7 @@
 use alloc::sync::Arc;
-use std::convert::TryFrom;
 
 use anyhow::Result;
 use ethers::prelude::*;
-use ethers::providers::{Http, Middleware, Provider};
-use ethers::types::{Address, H256, U256};
 use ethers::utils::keccak256;
 use log::info;
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-01-25"
+channel = "nightly-2024-02-22"
 components = ["llvm-tools", "rustc-dev"]

--- a/rustx/Cargo.toml
+++ b/rustx/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
+edition = "2021"
 name = "rustx"
 version = "0.1.0"
-edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+ci = []
 default = ["parallel", "std", "timing"]
 parallel = ["plonky2/parallel"]
 std = ["plonky2/std"]
 timing = ["plonky2/timing"]
-ci = []
 
 [dependencies]
 alloy-primitives = "0.4.2"
@@ -21,13 +21,13 @@ env_logger = "0.10.0"
 ethers = "2.0.10"
 hex = "0.4.3"
 log = "0.4.20"
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", default-features = false, rev = "d2598bd" }
-plonky2x = { path = "../plonky2x/core" }
+plonky2 = {git = "https://github.com/mir-protocol/plonky2.git", default-features = false, version = "0.2.0"}
+plonky2x = {path = "../plonky2x/core"}
 serde = "1.0.188"
 serde_json = "1.0.107"
 tokio = "1.33.0"
 
 [dev-dependencies]
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "d2598bd", features = [
-    "gate_testing",
-] }
+plonky2 = {git = "https://github.com/mir-protocol/plonky2.git", version = "0.2.0", features = [
+  "gate_testing",
+]}


### PR DESCRIPTION
Remove lock on dalek, pin plonky2 to version 0.2.0 and fix clippy issues.

Dalek was locked because nightly support for `#[stdsimd]` was removed.

NEAR needs `curve25519-dalek` at `4.1.1`, so remove unnecessary lock.

See https://github.com/dalek-cryptography/curve25519-dalek/pull/619
See https://github.com/0xPolygonZero/plonky2/pull/1524
