### PR TITLE
refactor: proof timeout

### DIFF
--- a/plonky2x/core/src/backend/prover/remote.rs
+++ b/plonky2x/core/src/backend/prover/remote.rs
@@ -62,11 +62,12 @@ impl RemoteProver {
             .expect("failed to submit proof request");
 
         // Default timeout for a proof is 60 minutes. Users can override this value by
-        // setting the PROOF_TIMEOUT_MINS environment variable.
-        const DEFAULT_PROOF_TIMEOUT_MINS: u64 = 60;
-        let proof_timeout_mins =
-            env::var("PROOF_TIMEOUT_MINS").unwrap_or(DEFAULT_PROOF_TIMEOUT_MINS.to_string());
-        let proof_timeout_secs = proof_timeout_mins.parse::<u64>().unwrap() * 60;
+        // setting the PROOF_TIMEOUT_SECS environment variable.
+        const DEFAULT_PROOF_TIMEOUT_SECS: u64 = 60 * 60;
+        let proof_timeout_secs = env::var("PROOF_TIMEOUT_SECS")
+            .unwrap_or(DEFAULT_PROOF_TIMEOUT_SECS.to_string())
+            .parse::<u64>()
+            .unwrap();
         let poll_secs = 10;
         // Maximum number of polls for proof status before timeout.
         let max_polls = proof_timeout_secs / poll_secs;
@@ -122,15 +123,16 @@ impl RemoteProver {
             .collect_vec();
         let (batch_id, proof_ids) = service.submit_batch(&requests)?;
 
-        // Default timeout for a batch proof is 60 minutes. Users can override this value by
-        // setting the BATCH_PROOF_TIMEOUT_MINS environment variable.
-        const DEFAULT_BATCH_PROOF_TIMEOUT_MINS: u64 = 60;
-        let proof_timeout_mins = env::var("BATCH_PROOF_TIMEOUT_MINS")
-            .unwrap_or(DEFAULT_BATCH_PROOF_TIMEOUT_MINS.to_string());
-        let proof_timeout_secs = proof_timeout_mins.parse::<u64>().unwrap() * 60;
+        // Default timeout for a proof is 60 minutes. Users can override this value by
+        // setting the PROOF_TIMEOUT_SECS environment variable.
+        const DEFAULT_PROOF_BATCH_TIMEOUT_SECS: u64 = 60 * 60;
+        let proof_batch_timeout_secs = env::var("PROOF_BATCH_TIMEOUT_SECS")
+            .unwrap_or(DEFAULT_PROOF_BATCH_TIMEOUT_SECS.to_string())
+            .parse::<u64>()
+            .unwrap();
         let poll_secs = 10;
         // Maximum number of polls for proof status before timeout.
-        let max_polls = proof_timeout_secs / poll_secs;
+        let max_polls = proof_batch_timeout_secs / poll_secs;
 
         for i in 0..max_polls {
             sleep(Duration::from_secs(poll_secs)).await;

--- a/plonky2x/core/src/backend/prover/remote.rs
+++ b/plonky2x/core/src/backend/prover/remote.rs
@@ -67,12 +67,13 @@ impl RemoteProver {
         let proof_timeout_mins =
             env::var("PROOF_TIMEOUT_MINS").unwrap_or(DEFAULT_PROOF_TIMEOUT_MINS.to_string());
         let proof_timeout_secs = proof_timeout_mins.parse::<u64>().unwrap() * 60;
-        let poll_delay_secs = 10;
-        let max_polls = proof_timeout_secs / poll_delay_secs;
+        let poll_secs = 10;
+        // Maximum number of polls for proof status before timeout.
+        let max_polls = proof_timeout_secs / poll_secs;
 
         let mut status = ProofRequestStatus::Pending;
         for i in 0..max_polls {
-            sleep(Duration::from_secs(poll_delay_secs)).await;
+            sleep(Duration::from_secs(poll_secs)).await;
             let request = service.get::<L, D>(proof_id)?;
             debug!(
                 "proof {:?}: status={:?}, nb_polls={}/{}",
@@ -127,11 +128,12 @@ impl RemoteProver {
         let proof_timeout_mins = env::var("BATCH_PROOF_TIMEOUT_MINS")
             .unwrap_or(DEFAULT_BATCH_PROOF_TIMEOUT_MINS.to_string());
         let proof_timeout_secs = proof_timeout_mins.parse::<u64>().unwrap() * 60;
-        let poll_delay_secs = 10;
-        let max_polls = proof_timeout_secs / poll_delay_secs;
+        let poll_secs = 10;
+        // Maximum number of polls for proof status before timeout.
+        let max_polls = proof_timeout_secs / poll_secs;
 
         for i in 0..max_polls {
-            sleep(Duration::from_secs(poll_delay_secs)).await;
+            sleep(Duration::from_secs(poll_secs)).await;
             let request = match service.get_batch::<L, D>(batch_id) {
                 Ok(request) => request,
                 Err(e) => {

--- a/plonky2x/core/src/backend/prover/remote.rs
+++ b/plonky2x/core/src/backend/prover/remote.rs
@@ -123,8 +123,8 @@ impl RemoteProver {
             .collect_vec();
         let (batch_id, proof_ids) = service.submit_batch(&requests)?;
 
-        // Default timeout for a proof is 60 minutes. Users can override this value by
-        // setting the PROOF_TIMEOUT_SECS environment variable.
+        // Default timeout for a batch proof is 60 minutes. Users can override this value by
+        // setting the PROOF_BATCH_TIMEOUT_SECS environment variable.
         const DEFAULT_PROOF_BATCH_TIMEOUT_SECS: u64 = 60 * 60;
         let proof_batch_timeout_secs = env::var("PROOF_BATCH_TIMEOUT_SECS")
             .unwrap_or(DEFAULT_PROOF_BATCH_TIMEOUT_SECS.to_string())

--- a/plonky2x/core/src/backend/prover/remote.rs
+++ b/plonky2x/core/src/backend/prover/remote.rs
@@ -63,7 +63,7 @@ impl RemoteProver {
 
         // Default timeout for a proof is 60 minutes. Users can override this value by
         // setting the PROOF_TIMEOUT_MINS environment variable.
-        const DEFAULT_PROOF_TIMEOUT_MINS: usize = 60;
+        const DEFAULT_PROOF_TIMEOUT_MINS: u64 = 60;
         let proof_timeout_mins =
             env::var("PROOF_TIMEOUT_MINS").unwrap_or(DEFAULT_PROOF_TIMEOUT_MINS.to_string());
         let proof_timeout_secs = proof_timeout_mins.parse::<u64>().unwrap() * 60;
@@ -123,7 +123,7 @@ impl RemoteProver {
 
         // Default timeout for a batch proof is 60 minutes. Users can override this value by
         // setting the BATCH_PROOF_TIMEOUT_MINS environment variable.
-        const DEFAULT_BATCH_PROOF_TIMEOUT_MINS: usize = 60;
+        const DEFAULT_BATCH_PROOF_TIMEOUT_MINS: u64 = 60;
         let proof_timeout_mins = env::var("BATCH_PROOF_TIMEOUT_MINS")
             .unwrap_or(DEFAULT_BATCH_PROOF_TIMEOUT_MINS.to_string());
         let proof_timeout_secs = proof_timeout_mins.parse::<u64>().unwrap() * 60;


### PR DESCRIPTION
## Overview
- Reduce the default timeout for proofs & batch proofs.
- Let users set configuration for proof and batch proof timeout via `PROOF_BATCH_TIMEOUT_SECS` and `PROOF_TIMEOUT_SECS`.