### PR TITLE
feat: Make num mod public

### DIFF
--- a/plonky2x/core/src/frontend/uint/mod.rs
+++ b/plonky2x/core/src/frontend/uint/mod.rs
@@ -6,7 +6,7 @@ pub mod uint32;
 pub mod uint512;
 pub mod uint64;
 
-pub(crate) mod num;
+pub mod num;
 
 mod uint32_n;
 


### PR DESCRIPTION
Making the num module public enables the use of `BigUintTarget`.